### PR TITLE
Update useGageChartOptions.ts

### DIFF
--- a/app/utils/useGageChartOptions.ts
+++ b/app/utils/useGageChartOptions.ts
@@ -424,6 +424,13 @@ const buildBasicOptions = (props: BuildOptionsProps, t) => {
         week: "%e. %b",
         month: "%b '%y",
       },
+      labels: {
+        formatter: function () {
+          return localDayJs
+            .tz(this.value, gage?.timeZoneName)
+            .format("MMM D, h:mm A");  // Match tooltip
+        },
+      },
     },
     yAxis: {
       type: (chartDataType === GageChartDataType.DISCHARGE) ? "logarithmic" : "linear",


### PR DESCRIPTION
This ensures x-axis ticks use the same time zone and format as the tooltip.

<img width="1122" height="432" alt="Screenshot 2025-09-19 at 1 50 08 AM" src="https://github.com/user-attachments/assets/d32aeaa1-2326-4ea7-aa5a-c27b59f7efb7" />
