### PR TITLE
Remove Picker prompt because it crashes on Android

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -4,7 +4,7 @@
   },
   "build": {
     "production": {
-      "node": "18.20.8",
+      "node": "20.19.5",
       "channel": "production",
       "autoIncrement": true
     },

--- a/package.json
+++ b/package.json
@@ -88,6 +88,6 @@
   },
   "main": "expo-router/entry",
   "name": "floodzuki",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true
 }

--- a/src/components/GageDetailsChart.tsx
+++ b/src/components/GageDetailsChart.tsx
@@ -106,7 +106,6 @@ const PickerSelector = ({
 
   return (
     <Picker
-      prompt={t("gageDetailsChart.selectEvent")}
       selectedValue={eventId}
       onValueChange={onHistoricEventSelected}
       style={[$pickerStyle, width]}


### PR DESCRIPTION
remove picker prompt (not sure how this change got lost).  In the current version of expo/react-native, if you have a react-native-picker Picker, and it has a "prompt" field, and that control is on a page that gets navigated to/away from (like our gauge details page), there is a native crash.

bump app version for release process.

fix node version for eas build.