### PR TITLE
survive having usgs readings without discharge numbers

### DIFF
--- a/src/models/Forecasts.ts
+++ b/src/models/Forecasts.ts
@@ -132,7 +132,7 @@ export const NOAAForecastModel = types
 const ReadingModel = types
   .model("Reading")
   .props({
-    discharges: types.array(types.number),
+    discharges: types.array(types.maybeNull(types.number)),
     readingIds: types.array(types.number),
     timestamps: types.array(types.string),
     trendCfsPerHour: types.maybe(types.number),

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -12,7 +12,7 @@ export const useUtils = () => {
   }
   
   function formatFlow(flow) {
-    return flow?.toLocaleString(undefined, { maximumFractionDigits: 0 }) + ` ${t("measure.cfs")}`;
+    return flow ? (flow.toLocaleString(undefined, { maximumFractionDigits: 0 }) + ` ${t("measure.cfs")}`) : "";
   }
   
   function formatTrend(trend) {


### PR DESCRIPTION
Couple of minor tweaks to allow the app to not crash when USGS readings don't have values for discharge