### PR TITLE
fix: mock @sentry/react-native in Jest to clear open handle warning

### DIFF
--- a/__mocks__/@sentry/react-native.js
+++ b/__mocks__/@sentry/react-native.js
@@ -1,0 +1,13 @@
+module.exports = {
+  init: jest.fn(),
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+  addBreadcrumb: jest.fn(),
+  setUser: jest.fn(),
+  setTag: jest.fn(),
+  setExtra: jest.fn(),
+  withScope: jest.fn((cb) => cb({ setExtra: jest.fn() })),
+  wrap: jest.fn((component) => component),
+  ReactNativeTracing: jest.fn(),
+  ReactNavigationInstrumentation: jest.fn(),
+};

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
       "<rootDir>/node_modules/expo/node_modules"
     ],
     "moduleNameMapper": {
+      "^@sentry/react-native$": "<rootDir>/__mocks__/@sentry/react-native.js",
       "^@react-native-async-storage/async-storage$": "@react-native-async-storage/async-storage/jest/async-storage-mock",
       "^@assets/(.*)$": "<rootDir>/assets/$1",
       "^@utils/(.*)$": "<rootDir>/src/utils/$1",


### PR DESCRIPTION
AsyncExpiringMap in @sentry/react-native creates a setInterval as a module-level side effect when imported. Adding a manual mock via moduleNameMapper prevents the real SDK from loading in tests. With help from Claude.

# Fix Jest Open Handle Warning — @sentry/react-native timer

**Goal:** Eliminate the Jest "open handle" warning caused by `@sentry/react-native` starting an internal `setInterval` when imported during tests.

**Architecture:** Add a manual mock for `@sentry/react-native` at `__mocks__/@sentry/react-native.js`, then wire it into the Jest `moduleNameMapper` so the real SDK is never imported in any test. This prevents `AsyncExpiringMap.startCleanup` from creating the offending timer.

**Tech Stack:** Jest 29, jest-expo preset, `@sentry/react-native ~7.11.0`

---

## Root Cause (for context)

When `src/services/__tests__/pushNotifications.test.ts` runs, the following import chain executes:

```
pushNotifications.test.ts
  → pushNotifications.ts:9       (import { useLocale })
  → LocaleContext.tsx:5          (import { useStores })
  → models/helpers/useStores.ts  (imports RootStore)
  → models/RootStore.ts:7        (import { AuthSessionStoreModel })
  → models/AuthSession.ts:26     (import { logError } from "@utils/sentry")
  → utils/sentry.ts:1            (import * as Sentry from "@sentry/react-native")
  → @sentry/react-native         ← AsyncExpiringMap calls setInterval here
```

`AsyncExpiringMap` fires `setInterval` as a **module-level side effect** when the package is first `require()`-d. Because it is never cleared, Jest detects it as an open handle.

---

## File Map

| Action     | Path                                   | Purpose                                   |
| ---------- | -------------------------------------- | ----------------------------------------- |
| **Create** | `__mocks__/@sentry/react-native.js`    | Manual mock — no-op stubs, no real timers |
| **Modify** | `package.json` (jest.moduleNameMapper) | Point `@sentry/react-native` at the mock  |

---

## Task 1: Create the manual mock file

**Files:**

- Create: `__mocks__/@sentry/react-native.js`

- [ ] **Step 1.1: Create `__mocks__/` directory and write the mock**

  ```js
  // __mocks__/@sentry/react-native.js
  module.exports = {
    init: jest.fn(),
    captureException: jest.fn(),
    captureMessage: jest.fn(),
    addBreadcrumb: jest.fn(),
    setUser: jest.fn(),
    setTag: jest.fn(),
    setExtra: jest.fn(),
    withScope: jest.fn((cb) => cb({ setExtra: jest.fn() })),
    wrap: jest.fn((component) => component),
    ReactNativeTracing: jest.fn(),
    ReactNavigationInstrumentation: jest.fn(),
  };
  ```

  The `withScope` stub calls the callback synchronously so any code that calls it doesn't hang. All other exports are `jest.fn()` no-ops.

- [ ] **Step 1.2: Verify the file exists**

  Run:

  ```bash
  cat __mocks__/@sentry/react-native.js
  ```

  Expected: prints the file contents above.

---

## Task 2: Wire the mock into the Jest moduleNameMapper

**Files:**

- Modify: `package.json` — `jest.moduleNameMapper` section

The current `moduleNameMapper` in `package.json` looks like:

```json
"moduleNameMapper": {
  "^@react-native-async-storage/async-storage$": "@react-native-async-storage/async-storage/jest/async-storage-mock",
  "^@assets/(.*)$": "<rootDir>/assets/$1",
  "^@utils/(.*)$": "<rootDir>/src/utils/$1",
  ...
}
```

- [ ] **Step 2.1: Add the Sentry entry to moduleNameMapper**

  Add this line to the `jest.moduleNameMapper` object in `package.json`:

  ```json
  "^@sentry/react-native$": "<rootDir>/__mocks__/@sentry/react-native.js"
  ```

  The full `jest` block should look like:

  ```json
  "jest": {
    "preset": "jest-expo",
    "modulePaths": [
      "<rootDir>/node_modules/expo/node_modules"
    ],
    "moduleNameMapper": {
      "^@sentry/react-native$": "<rootDir>/__mocks__/@sentry/react-native.js",
      "^@react-native-async-storage/async-storage$": "@react-native-async-storage/async-storage/jest/async-storage-mock",
      "^@assets/(.*)$": "<rootDir>/assets/$1",
      "^@utils/(.*)$": "<rootDir>/src/utils/$1",
      "^@services/(.*)$": "<rootDir>/src/services/$1",
      "^@models/(.*)$": "<rootDir>/src/models/$1",
      "^@components/(.*)$": "<rootDir>/src/components/$1",
      "^@common-ui/(.*)$": "<rootDir>/src/common-ui/$1",
      "^@config/(.*)$": "<rootDir>/src/config/$1",
      "^@i18n/(.*)$": "<rootDir>/src/i18n/$1"
    }
  }
  ```

---

## Task 3: Verify the fix

- [ ] **Step 3.1: Run tests normally and confirm all still pass**

  ```bash
  npx jest
  ```

  Expected:

  ```
  Test Suites: 6 passed, 6 total
  Tests:       31 passed, 31 total
  ```

  No "worker process has failed to exit gracefully" warning.

- [ ] **Step 3.2: Run with --detectOpenHandles to confirm the timer is gone**

  ```bash
  npx jest --detectOpenHandles
  ```

  Expected: all tests pass, **no** "Jest has detected the following 1 open handle" section in the output.

  If the warning still appears, check that the `moduleNameMapper` regex `^@sentry/react-native$` is an exact match (not a substring) and that the mock file path is correct.

---

## Task 4: Commit

- [ ] **Step 4.1: Stage and commit**

  ```bash
  git add __mocks__/@sentry/react-native.js package.json
  git commit -m "$(cat <<'EOF'
  fix: mock @sentry/react-native in Jest to clear open handle warning

  AsyncExpiringMap in @sentry/react-native creates a setInterval as a
  module-level side effect when imported. Adding a manual mock via
  moduleNameMapper prevents the real SDK from loading in tests.
  With help from Claude.
  EOF
  )"
  ```

---

## Self-Review Checklist

- [x] **Spec coverage:** single warning → single root cause → single mock → confirmed gone with `--detectOpenHandles`
- [x] **No placeholders:** all code blocks are complete and literal
- [x] **Type consistency:** no types defined in this plan (plain JS mock file)
- [x] **No side effects on other tests:** `moduleNameMapper` intercepts the import globally; `src/utils/sentry.ts` (`logError`, `initSentry`) calls `Sentry.init` / `Sentry.captureException` which are now `jest.fn()` stubs — no breakage
