### PR TITLE
Feature/remember app banner close

### DIFF
--- a/app/(root)/_layout.tsx
+++ b/app/(root)/_layout.tsx
@@ -30,7 +30,7 @@ import { useCheckForUpdates } from "@services/expoUpdates";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
 import LocaleChange from "@components/LocaleChange";
 import TasteOfTheValleyBanner from "@components/TasteOfTheValleyBanner";
-import AndroidPlayMarketBanner from "@components/AndroidPlayMarketBanner";
+import AppStoreBanner from "@components/AppStoreBanner";
 
 const GAGE_ICONS = {
   active: require("@assets/images/floodzuki.png"),
@@ -64,7 +64,7 @@ export default function AppLayout() {
   return (
     <Ternary condition={isWeb}>
       <>
-        <AndroidPlayMarketBanner />
+        <AppStoreBanner />
         <Header />
         <TasteOfTheValleyBanner />
         <Slot />

--- a/src/components/AppStoreBanner.tsx
+++ b/src/components/AppStoreBanner.tsx
@@ -11,7 +11,7 @@ import { openLinkInBrowser } from "@utils/navigation";
 import { Colors } from "@common-ui/constants/colors";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
 
-const TasteOfTheValleyBanner = () => {
+const AppStoreBanner = () => {
   const { isMobile } = useResponsive();
   const { getAsset } = useAppAssets();
   const { t } = useLocale();
@@ -76,4 +76,4 @@ const TasteOfTheValleyBanner = () => {
   );
 };
 
-export default TasteOfTheValleyBanner;
+export default AppStoreBanner;

--- a/src/components/AppStoreBanner.tsx
+++ b/src/components/AppStoreBanner.tsx
@@ -11,12 +11,28 @@ import { openLinkInBrowser } from "@utils/navigation";
 import { Colors } from "@common-ui/constants/colors";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
 
+const STORAGE_KEY = "install_banner_dismissed_at";
+const SUPPRESS_DAYS = 30;
+
+export function isBannerSuppressed(): boolean {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return false;
+    const dismissedAt = new Date(raw).getTime();
+    if (isNaN(dismissedAt)) return false;
+    const cutoff = Date.now() - SUPPRESS_DAYS * 24 * 60 * 60 * 1000;
+    return dismissedAt > cutoff;
+  } catch {
+    return false;
+  }
+}
+
 const AppStoreBanner = () => {
   const { isMobile } = useResponsive();
   const { getAsset } = useAppAssets();
   const { t } = useLocale();
 
-  const [isBannerVisible, setIsBannerVisible] = useState(true);
+  const [isBannerVisible, setIsBannerVisible] = useState(() => !isBannerSuppressed());
 
   const openPlayMarket = () => {
     openLinkInBrowser("https://play.google.com/store/apps/details?id=com.floodzilla.floodzuki");
@@ -35,6 +51,7 @@ const AppStoreBanner = () => {
   };
 
   const closeBanner = () => {
+    localStorage.setItem(STORAGE_KEY, new Date().toISOString());
     setIsBannerVisible(false);
   };
 

--- a/src/components/AppStoreBanner.tsx
+++ b/src/components/AppStoreBanner.tsx
@@ -17,9 +17,13 @@ const SUPPRESS_DAYS = 30;
 export function isBannerSuppressed(): boolean {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return false;
+    if (!raw) {
+      return false;
+    }
     const dismissedAt = new Date(raw).getTime();
-    if (isNaN(dismissedAt)) return false;
+    if (isNaN(dismissedAt)) {
+      return false;
+    }
     const cutoff = Date.now() - SUPPRESS_DAYS * 24 * 60 * 60 * 1000;
     return dismissedAt > cutoff;
   } catch {

--- a/src/components/__tests__/AppStoreBanner.test.ts
+++ b/src/components/__tests__/AppStoreBanner.test.ts
@@ -3,18 +3,6 @@
  */
 
 // Mock modules that don't work in jsdom environment
-jest.mock("@sentry/react-native", () => ({
-  init: jest.fn(),
-  captureException: jest.fn(),
-}));
-
-jest.mock("@react-native-async-storage/async-storage", () => ({
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  removeItem: jest.fn(),
-  clear: jest.fn(),
-}));
-
 jest.mock("expo-notifications", () => ({
   getLastNotificationResponseAsync: jest.fn(),
   addNotificationResponseReceivedListener: jest.fn(),

--- a/src/components/__tests__/AppStoreBanner.test.ts
+++ b/src/components/__tests__/AppStoreBanner.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// Mock modules that don't work in jsdom environment
+jest.mock("@sentry/react-native", () => ({
+  init: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  clear: jest.fn(),
+}));
+
+jest.mock("expo-notifications", () => ({
+  getLastNotificationResponseAsync: jest.fn(),
+  addNotificationResponseReceivedListener: jest.fn(),
+}));
+
+jest.mock("expo-device", () => ({
+  isDevice: false,
+}));
+
+jest.mock("expo-image", () => ({
+  Image: "Image",
+}));
+
+jest.mock("expo-router", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock("@common-ui/contexts/LocaleContext", () => ({
+  useLocale: jest.fn(() => ({ t: jest.fn((key) => key) })),
+}));
+
+jest.mock("@common-ui/contexts/AssetsContext", () => ({
+  useAppAssets: jest.fn(),
+}));
+
+jest.mock("@common-ui/utils/responsive", () => ({
+  useResponsive: jest.fn(),
+  isWeb: false,
+  isAndroid: true,
+}));
+
+jest.mock("@utils/navigation", () => ({
+  openLinkInBrowser: jest.fn(),
+}));
+
+import { isBannerSuppressed } from "../AppStoreBanner";
+
+const STORAGE_KEY = "install_banner_dismissed_at";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("isBannerSuppressed", () => {
+  it("returns false when nothing is stored", () => {
+    expect(isBannerSuppressed()).toBe(false);
+  });
+
+  it("returns true when dismissed less than 30 days ago", () => {
+    const recentTimestamp = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    localStorage.setItem(STORAGE_KEY, recentTimestamp);
+    expect(isBannerSuppressed()).toBe(true);
+  });
+
+  it("returns false when dismissed exactly 30 days ago", () => {
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    localStorage.setItem(STORAGE_KEY, thirtyDaysAgo);
+    expect(isBannerSuppressed()).toBe(false);
+  });
+
+  it("returns false when dismissed more than 30 days ago", () => {
+    const oldTimestamp = new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString();
+    localStorage.setItem(STORAGE_KEY, oldTimestamp);
+    expect(isBannerSuppressed()).toBe(false);
+  });
+
+  it("returns false when stored value is not a valid date string", () => {
+    localStorage.setItem(STORAGE_KEY, "not-a-date");
+    expect(isBannerSuppressed()).toBe(false);
+  });
+});


### PR DESCRIPTION
# App Store Banner — Persistent Dismissal

**Date:** 2026-04-26

## Problem

The mobile web install banner (`AndroidPlayMarketBanner`) reappears on every page reload after the user dismisses it, because visibility is tracked only in React state. Users who dismiss it must dismiss it again each visit.

## Goal

Persist the dismissal for 30 days. Each time the user dismisses the banner, the 30-day window resets. After 30 days the banner reappears once, and the cycle repeats.

## Scope

All changes are confined to one component file and one import update. No store changes, no new dependencies, no API calls.

## Design

### Rename

`AndroidPlayMarketBanner.tsx` → `AppStoreBanner.tsx`, component name `TasteOfTheValleyBanner` → `AppStoreBanner`. The old name was inaccurate (the banner links to both the Apple App Store and Google Play). Update the import in `app/(root)/_layout.tsx` accordingly.

### Storage

Use `localStorage` directly (not `AsyncStorage` / `storage.ts`). The banner is already web-only — it is rendered only inside `<Ternary condition={isWeb}>` in the root layout and guards itself with `if (!isMobile)`. `localStorage` is synchronous, which avoids a render-cycle flash.

- **Key:** `install_banner_dismissed_at`
- **Value:** ISO timestamp string (e.g. `"2026-04-26T17:00:00.000Z"`)

### Helper function

```ts
const STORAGE_KEY = "install_banner_dismissed_at";
const SUPPRESS_DAYS = 30;

function isBannerSuppressed(): boolean {
  try {
    const raw = localStorage.getItem(STORAGE_KEY);
    if (!raw) return false;
    const dismissedAt = new Date(raw).getTime();
    const cutoff = Date.now() - SUPPRESS_DAYS * 24 * 60 * 60 * 1000;
    return dismissedAt > cutoff;
  } catch {
    return false;
  }
}
```

The `try/catch` handles environments where `localStorage` is unavailable (private browsing with strict settings, SSR, etc.) — the banner shows by default in those cases.

### State initialization

```ts
const [isBannerVisible, setIsBannerVisible] = useState(() => !isBannerSuppressed());
```

The lazy initializer runs once on mount. Because `localStorage` is synchronous the correct value is available before the first render, so there is no visible flash.

### Dismiss handler

```ts
const closeBanner = () => {
  localStorage.setItem(STORAGE_KEY, new Date().toISOString());
  setIsBannerVisible(false);
};
```

Writing the timestamp on every dismissal resets the 30-day window, which is the intended behavior.

## Files changed

| File | Change |
|------|--------|
| `src/components/AndroidPlayMarketBanner.tsx` | Renamed to `AppStoreBanner.tsx`; component renamed; persistence logic added |
| `app/(root)/_layout.tsx` | Import updated from `AndroidPlayMarketBanner` to `AppStoreBanner` |

## Out of scope

- Server-side or cross-device persistence (not needed; this is a per-browser UX preference)
- Applying the same pattern to `TasteOfTheValleyBanner` (that component auto-hides based on date and is effectively dead code)
- Exposing the suppression state to the MobX store
