### PR TITLE
fix: coerce forecastsEnabled and dailyForecastsEnabled to boolean before passing to CheckBoxItem

### DIFF
--- a/app/(root)/user/alerts.tsx
+++ b/app/(root)/user/alerts.tsx
@@ -127,7 +127,7 @@ const AlertSettingsCard = observer(function AlertSettings() {
               label={`${t("alertsScreen.sendEmailAlertsTo")}: ${
                 isLoggedIn ? authSessionStore.user?.email : ""
               }`}
-              value={emailAlertsEnabled && isLoggedIn}
+              value={(emailAlertsEnabled ?? false) && isLoggedIn}
               onChange={updateEmailAlertsEnabled}
             />
           </Cell>
@@ -151,7 +151,7 @@ const AlertSettingsCard = observer(function AlertSettings() {
               isLoading={isUpdatingSms}
               disabled={!isPhoneVerified || !isLoggedIn}
               label={`${t("alertsScreen.sendSmsAlerts")}: ${authSessionStore.userPhone ?? ""}`}
-              value={smsAlertsEnabled && isLoggedIn}
+              value={(smsAlertsEnabled ?? false) && isLoggedIn}
               onChange={updateSmsAlertsEnabled}
             />
           </Cell>
@@ -233,14 +233,14 @@ const ForecastsCard = observer(function ForecastsCard() {
           disabled={!isNotificationsEnabled || !isLoggedIn}
           isLoading={isUpdatingForecast}
           label={t("alertsScreen.genericForecast")}
-          value={forecastsEnabled}
+          value={forecastsEnabled ?? false}
           onChange={updateForecastsEnabled}
         />
         <CheckBoxItem
           disabled={!isNotificationsEnabled || !isLoggedIn}
           isLoading={isUpdatingDailyForecast}
           label={t("alertsScreen.dailyForecast")}
-          value={dailyForecastsEnabled}
+          value={dailyForecastsEnabled ?? false}
           onChange={updateDailyForecastsEnabled}
         />
       </CardContent>


### PR DESCRIPTION
using `??` operator to coerce `undefined` values to be `false`

Error seen:
<img width="942" height="657" alt="image" src="https://github.com/user-attachments/assets/66a8ce35-80f9-434a-aa67-b6f255b41f5b" />
