### PR TITLE
fix: lint type redeclare require imports

### DIFF
--- a/src/components/GageMap.tsx
+++ b/src/components/GageMap.tsx
@@ -5,8 +5,11 @@ import { Gage } from "../models/Gage";
 import { useMemo } from "react";
 
 const Map = Platform.select({
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   ios: () => require("./MapLibreMobileGageMap").default,
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   android: () => require("./MapLibreMobileGageMap").default,
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   default: () => require("./MapLibreWebGageMap").default,
 })();
 

--- a/src/components/GoogleRecaptcha.tsx
+++ b/src/components/GoogleRecaptcha.tsx
@@ -28,12 +28,12 @@ type GoogleRecaptchaProps = {
   onExpire: () => void;
 };
 
-type WebRecpatcha = Pick<GoogleRecaptchaProps, "onVerify" | "onExpire">;
+type WebRecaptchaProps = Pick<GoogleRecaptchaProps, "onVerify" | "onExpire">;
 
 const RECAPTCHA_KEY = Constants.expoConfig.extra.recaptchaKey;
 
 // eslint-disable-next-line react/display-name
-const WebRecpatcha = React.forwardRef(({ onVerify, onExpire }: WebRecpatcha, ref) => {
+const WebRecaptchaInner = React.forwardRef(({ onVerify, onExpire }: WebRecaptchaProps, ref) => {
   const isRendered = useRef(false);
 
   const uniqueId = Math.random().toString(36).substring(2, 15);
@@ -107,7 +107,7 @@ const GoogleRecaptcha = React.forwardRef((props: GoogleRecaptchaProps, ref) => {
 
   return (
     <Ternary condition={isWeb}>
-      <WebRecpatcha ref={recaptchaWeb} onVerify={onVerify} onExpire={onExpire} />
+      <WebRecaptchaInner ref={recaptchaWeb} onVerify={onVerify} onExpire={onExpire} />
       <Recaptcha
         ref={recaptcha as any}
         siteKey={RECAPTCHA_KEY}

--- a/src/components/__tests__/GoogleRecaptcha.test.tsx
+++ b/src/components/__tests__/GoogleRecaptcha.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import GoogleRecaptcha from "../GoogleRecaptcha";
+
+jest.mock("expo-constants", () => ({
+  __esModule: true,
+  default: {
+    expoConfig: {
+      extra: { recaptchaKey: "test-key" },
+    },
+  },
+}));
+
+jest.mock("expo-router", () => ({
+  useFocusEffect: jest.fn(),
+}));
+
+jest.mock("react-native-recaptcha-that-works", () => "Recaptcha");
+
+jest.mock("@common-ui/components/Conditional", () => ({
+  Ternary: ({ condition, children }: { condition: boolean; children: React.ReactNode[] }) =>
+    condition ? children[0] : children[1],
+}));
+
+jest.mock("@common-ui/utils/responsive", () => ({
+  isWeb: false,
+}));
+
+jest.mock("@utils/sentry", () => ({
+  logError: jest.fn(),
+}));
+
+describe("GoogleRecaptcha", () => {
+  it("renders without crashing", () => {
+    const onVerify = jest.fn();
+    const onExpire = jest.fn();
+    expect(() => render(<GoogleRecaptcha onVerify={onVerify} onExpire={onExpire} />)).not.toThrow();
+  });
+});


### PR DESCRIPTION
# PR 1 of 3

**Goal:** Resolve the four highest-priority ESLint warning categories — type redeclaration, require-style imports, ternaries used as side-effects, and stale-closure exhaustive-deps — and add unit tests for the two most-testable changes.

## Task1: Fix GoogleRecaptcha no-redeclare

The type `WebRecpatcha` and the component const `WebRecpatcha` share the same (typo'd) name. Rename the type to `WebRecaptchaProps` and fix the typo everywhere in the file.

**Files:**
- Modify: `src/components/GoogleRecaptcha.tsx:31,36`
- Create: `src/components/__tests__/GoogleRecaptcha.test.tsx`

- [ ] **Step 1: Write the failing test**

Create `src/components/__tests__/GoogleRecaptcha.test.tsx`:

```tsx
import React from "react";
import { render } from "@testing-library/react-native";
import GoogleRecaptcha from "../GoogleRecaptcha";

jest.mock("expo-constants", () => ({
  default: {
    expoConfig: {
      extra: { recaptchaKey: "test-key" },
    },
  },
}));

jest.mock("expo-router", () => ({
  useFocusEffect: jest.fn(),
}));

jest.mock("react-native-recaptcha-that-works", () => "Recaptcha");

jest.mock("@common-ui/components/Conditional", () => ({
  Ternary: ({ condition, children }: { condition: boolean; children: React.ReactNode[] }) =>
    condition ? children[0] : children[1],
}));

jest.mock("@common-ui/utils/responsive", () => ({
  isWeb: false,
}));

jest.mock("@utils/sentry", () => ({
  logError: jest.fn(),
}));

describe("GoogleRecaptcha", () => {
  it("renders without crashing", () => {
    const onVerify = jest.fn();
    const onExpire = jest.fn();
    expect(() =>
      render(<GoogleRecaptcha onVerify={onVerify} onExpire={onExpire} />)
    ).not.toThrow();
  });
});
```

- [ ] **Step 2: Run the test to confirm the component works at runtime**

```bash
npx jest src/components/__tests__/GoogleRecaptcha.test.tsx --no-coverage
```

Expected: PASS — `no-redeclare` is a lint warning, not a build error. The component compiles and renders fine. This step confirms the smoke test is valid before we touch the source.

- [ ] **Step 3: Rename the type and const in GoogleRecaptcha.tsx**

In `src/components/GoogleRecaptcha.tsx`, make three changes:

Line 31 — rename the type (and fix the typo):
```ts
type WebRecaptchaProps = Pick<GoogleRecaptchaProps, "onVerify" | "onExpire">;
```

Line 36 — rename the const and update its props annotation:
```tsx
const WebRecaptchaInner = React.forwardRef(({ onVerify, onExpire }: WebRecaptchaProps, ref) => {
```

Line 110 — update the JSX usage:
```tsx
<WebRecaptchaInner ref={recaptchaWeb} onVerify={onVerify} onExpire={onExpire} />
```

- [ ] **Step 4: Run test, type-check, and confirm the warning is gone**

```bash
npx jest src/components/__tests__/GoogleRecaptcha.test.tsx --no-coverage
npx tsc --noEmit
npx eslint src/components/GoogleRecaptcha.tsx
```

Expected: test PASS, no TypeScript errors, no ESLint warnings.

---

## Task 2: Suppress no-require-imports in GageMap

`GageMap.tsx` uses `Platform.select(() => require(...))` — a lazy-load pattern required for platform splitting. Converting to static `import` would bundle both map implementations on both platforms. The correct fix is to suppress the warning with a comment.

**Files:**
- Modify: `src/components/GageMap.tsx:8-10`

- [ ] **Step 1: Add eslint-disable comments**

In `src/components/GageMap.tsx`, change lines 7–11 from:

```ts
const Map = Platform.select({
  ios: () => require("./MapLibreMobileGageMap").default,
  android: () => require("./MapLibreMobileGageMap").default,
  default: () => require("./MapLibreWebGageMap").default,
})();
```

to:

```ts
const Map = Platform.select({
  // eslint-disable-next-line @typescript-eslint/no-require-imports
  ios: () => require("./MapLibreMobileGageMap").default,
  // eslint-disable-next-line @typescript-eslint/no-require-imports
  android: () => require("./MapLibreMobileGageMap").default,
  // eslint-disable-next-line @typescript-eslint/no-require-imports
  default: () => require("./MapLibreWebGageMap").default,
})();
```

- [ ] **Step 2: Verify warning is gone**

```bash
npx eslint src/components/GageMap.tsx
npx tsc --noEmit
```

Expected: no warnings from GageMap.tsx.