### PR TITLE
Fix/lint ternary side effects

### DIFF
--- a/app/(root)/forecast/[...id].tsx
+++ b/app/(root)/forecast/[...id].tsx
@@ -1,11 +1,5 @@
 import React, { useEffect } from "react";
-import {
-  ErrorBoundaryProps,
-  Stack,
-  useRouter,
-  useNavigation,
-  useGlobalSearchParams,
-} from "expo-router";
+import { ErrorBoundaryProps, Stack, useGlobalSearchParams } from "expo-router";
 import Head from "expo-router/head";
 
 import { observer } from "mobx-react-lite";
@@ -24,6 +18,7 @@ import { IconButton, LinkButton } from "@common-ui/components/Button";
 import { If, Ternary } from "@common-ui/components/Conditional";
 import { Colors } from "@common-ui/constants/colors";
 import { useTimeout } from "@utils/useTimeout";
+import { useGoBack } from "@utils/useGoBack";
 import { ROUTES } from "app/_layout";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
 import ForecastFooter from "@components/ForecastFooter";
@@ -37,8 +32,6 @@ export function ErrorBoundary(props: ErrorBoundaryProps) {
 const ForecastDetailsScreen = observer(function ForecastDetailsScreen() {
   const { id } = useGlobalSearchParams();
   const { t } = useLocale();
-  const router = useRouter();
-  const navigation = useNavigation();
   const store = useStores();
 
   const { isMobile } = useResponsive();
@@ -66,9 +59,7 @@ const ForecastDetailsScreen = observer(function ForecastDetailsScreen() {
     setHidden(false);
   }, Timing.zero);
 
-  const goBack = () => {
-    navigation.canGoBack() ? navigation.goBack() : router.push({ pathname: ROUTES.Forecast });
-  };
+  const goBack = useGoBack(ROUTES.Forecast);
 
   const forecastGage = hidden ? undefined : store.getForecastGage(gageId);
 

--- a/app/(root)/gage/[id].tsx
+++ b/app/(root)/gage/[id].tsx
@@ -1,13 +1,6 @@
 import React, { useState } from "react";
 import { TouchableOpacity } from "react-native";
-import {
-  ErrorBoundaryProps,
-  Link,
-  Stack,
-  useGlobalSearchParams,
-  useNavigation,
-  useRouter,
-} from "expo-router";
+import { ErrorBoundaryProps, Link, Stack, useGlobalSearchParams } from "expo-router";
 import Head from "expo-router/head";
 
 import { observer } from "mobx-react-lite";
@@ -39,6 +32,7 @@ import EmptyComponent from "@common-ui/components/EmptyComponent";
 import GageMap from "@components/GageMap";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
 import { useTimeout } from "@utils/useTimeout";
+import { useGoBack } from "@utils/useGoBack";
 import { Timing } from "@common-ui/constants/timing";
 
 // We use this to wrap each screen with an error boundary
@@ -124,8 +118,6 @@ const DownstreamGageLink = observer(function DownstreamGageLink({ gage, simple }
 });
 
 const GageDetailsScreen = observer(function GageDetailsScreen({ gage }: { gage: Gage }) {
-  const router = useRouter();
-  const navigation = useNavigation();
   const { gagesStore, regionStore } = useStores();
   const { t } = useLocale();
 
@@ -135,9 +127,7 @@ const GageDetailsScreen = observer(function GageDetailsScreen({ gage }: { gage: 
 
   const { isMobile } = useResponsive();
 
-  const goBack = () => {
-    navigation.canGoBack() ? navigation.goBack() : router.push({ pathname: ROUTES.Home });
-  };
+  const goBack = useGoBack(ROUTES.Home);
   return (
     <Screen>
       <Head>

--- a/app/(root)/user/createpassword.tsx
+++ b/app/(root)/user/createpassword.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { ErrorBoundaryProps, Stack, useNavigation, useRouter } from "expo-router";
+import { ErrorBoundaryProps, Stack, useRouter } from "expo-router";
+import { useGoBack } from "@utils/useGoBack";
 
 import { Screen, Content } from "@common-ui/components/Screen";
 import { ErrorDetails } from "@components/ErrorDetails";
@@ -19,7 +20,6 @@ export function ErrorBoundary(props: ErrorBoundaryProps) {
 
 const CreatePasswordScreen = observer(function CreatePasswordScreen() {
   const router = useRouter();
-  const navigation = useNavigation();
 
   const { authSessionStore } = useStores();
   const { t } = useLocale();
@@ -36,9 +36,7 @@ const CreatePasswordScreen = observer(function CreatePasswordScreen() {
     router.push({ pathname: ROUTES.UserChangeEmail });
   };
 
-  const goBack = () => {
-    navigation.canGoBack() ? navigation.goBack() : router.push({ pathname: ROUTES.UserProfile });
-  };
+  const goBack = useGoBack(ROUTES.UserProfile);
 
   return (
     <Screen>

--- a/app/(root)/user/profile.tsx
+++ b/app/(root)/user/profile.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from "react";
-import { ErrorBoundaryProps, Redirect, Stack, useNavigation, useRouter } from "expo-router";
+import { ErrorBoundaryProps, Redirect, Stack, useRouter } from "expo-router";
+import { useGoBack } from "@utils/useGoBack";
 import { observer } from "mobx-react-lite";
 
 import { Content, Screen } from "@common-ui/components/Screen";
@@ -38,7 +39,6 @@ const sanitizeInput = (s) => {
 
 const ProfileScreen = observer(function ProfileScreen() {
   const router = useRouter();
-  const navigation = useNavigation();
 
   const { t } = useLocale();
   const { authSessionStore } = useStores();
@@ -54,6 +54,8 @@ const ProfileScreen = observer(function ProfileScreen() {
     [email, firstName, lastName]
   );
   const [isFormValid] = useValidations(fieldsToValidate);
+
+  const goBack = useGoBack(ROUTES.About);
 
   if (!authSessionStore.isLoggedIn) {
     return <Redirect href={ROUTES.Home} />;
@@ -112,10 +114,6 @@ const ProfileScreen = observer(function ProfileScreen() {
 
   const changePassword = () => {
     router.push({ pathname: ROUTES.UserSetPassword });
-  };
-
-  const goBack = () => {
-    navigation.canGoBack() ? navigation.goBack() : router.push({ pathname: ROUTES.About });
   };
 
   return (

--- a/app/(root)/user/resetpassword.tsx
+++ b/app/(root)/user/resetpassword.tsx
@@ -1,11 +1,6 @@
 import React, { useState } from "react";
-import {
-  ErrorBoundaryProps,
-  Redirect,
-  useLocalSearchParams,
-  useNavigation,
-  useRouter,
-} from "expo-router";
+import { ErrorBoundaryProps, Redirect, useLocalSearchParams } from "expo-router";
+import { useGoBack } from "@utils/useGoBack";
 
 import { Screen, Content } from "@common-ui/components/Screen";
 import { ErrorDetails } from "@components/ErrorDetails";
@@ -25,8 +20,6 @@ export function ErrorBoundary(props: ErrorBoundaryProps) {
 }
 
 const ResetPasswordScreen = observer(function ResetPasswordScreen() {
-  const router = useRouter();
-  const navigation = useNavigation();
   const { t } = useLocale();
 
   const { userId, code } = useLocalSearchParams();
@@ -34,6 +27,8 @@ const ResetPasswordScreen = observer(function ResetPasswordScreen() {
   const { authSessionStore } = useStores();
 
   const [successMessage, setSuccessMessage] = useState<string>("");
+
+  const goBack = useGoBack(ROUTES.UserProfile);
 
   if (!userId || !code) {
     return <Redirect href={ROUTES.Home} />;
@@ -57,10 +52,6 @@ const ResetPasswordScreen = observer(function ResetPasswordScreen() {
     }
 
     setSuccessMessage(t("resetpasswordScreen.successMessage"));
-  };
-
-  const goBack = () => {
-    navigation.canGoBack() ? navigation.goBack() : router.push({ pathname: ROUTES.UserProfile });
   };
 
   return (

--- a/app/(root)/user/setpassword.tsx
+++ b/app/(root)/user/setpassword.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import { ErrorBoundaryProps, Stack, useNavigation, useRouter } from "expo-router";
+import { ErrorBoundaryProps, Stack } from "expo-router";
+import { useGoBack } from "@utils/useGoBack";
 
 import { Screen, Content } from "@common-ui/components/Screen";
 import { ErrorDetails } from "@components/ErrorDetails";
@@ -18,8 +19,6 @@ export function ErrorBoundary(props: ErrorBoundaryProps) {
 }
 
 const SetPasswordScreen = observer(function SetPasswordScreen() {
-  const router = useRouter();
-  const navigation = useNavigation();
   const { t } = useLocale();
 
   const { authSessionStore } = useStores();
@@ -38,9 +37,7 @@ const SetPasswordScreen = observer(function SetPasswordScreen() {
     setSuccessMessage(t("setpasswordScreen.successMessage"));
   };
 
-  const goBack = () => {
-    navigation.canGoBack() ? navigation.goBack() : router.push({ pathname: ROUTES.UserProfile });
-  };
+  const goBack = useGoBack(ROUTES.UserProfile);
 
   return (
     <Screen>

--- a/app/(root)/user/verifyPhoneNumber.tsx
+++ b/app/(root)/user/verifyPhoneNumber.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { ErrorBoundaryProps, Redirect, useNavigation, useRouter } from "expo-router";
+import { ErrorBoundaryProps, Redirect } from "expo-router";
+import { useGoBack } from "@utils/useGoBack";
 import { KeyboardAvoidingView, Platform } from "react-native";
 
 import { Screen, Content } from "@common-ui/components/Screen";
@@ -26,8 +27,6 @@ export function ErrorBoundary(props: ErrorBoundaryProps) {
 }
 
 const VerifyPhoneNumberScreen = observer(function VerifyPhoneNumberScreen() {
-  const router = useRouter();
-  const navigation = useNavigation();
   const { t } = useLocale();
 
   const { authSessionStore } = useStores();
@@ -45,6 +44,8 @@ const VerifyPhoneNumberScreen = observer(function VerifyPhoneNumberScreen() {
   // Code presence validation
   const codeFieldsToValidate = useMemo(() => ({ code }), [code]);
   const [isCodeValid] = useValidations(codeFieldsToValidate);
+
+  const goBack = useGoBack(ROUTES.UserAlerts);
 
   // Clear any errors when the screen is loaded
   useEffect(() => {
@@ -69,10 +70,6 @@ const VerifyPhoneNumberScreen = observer(function VerifyPhoneNumberScreen() {
     await authSessionStore.reauthenticate();
 
     setCodeVerified(true);
-  };
-
-  const goBack = () => {
-    navigation.canGoBack() ? navigation.goBack() : router.push({ pathname: ROUTES.UserAlerts });
   };
 
   const title = authSessionStore.userPhone

--- a/src/common-ui/components/DatePicker.tsx
+++ b/src/common-ui/components/DatePicker.tsx
@@ -311,32 +311,38 @@ const DatePickerComponent = React.forwardRef((props: DatePickerProps, ref) => {
 
       setIsOpen(true);
 
-      isMobile
-        ? bottomSheetModalRef.current?.present()
-        : datePickerContext.showPicker(
-            <AbsoluteContainer
-              sticks={["left"]}
-              zIndex={10}
-              top={pageY + Spacing.larger}
-              left={leftOffset}>
-              <Card width={PICKER_WIDTH} height={PICKER_HEIGHT}>
-                <DatePicker
-                  title={title}
-                  minYear={minYear}
-                  maxYear={maxYear}
-                  selectedDate={selectedDate}
-                  onChange={handleChange}
-                />
-              </Card>
-            </AbsoluteContainer>
-          );
+      if (isMobile) {
+        bottomSheetModalRef.current?.present();
+      } else {
+        datePickerContext.showPicker(
+          <AbsoluteContainer
+            sticks={["left"]}
+            zIndex={10}
+            top={pageY + Spacing.larger}
+            left={leftOffset}>
+            <Card width={PICKER_WIDTH} height={PICKER_HEIGHT}>
+              <DatePicker
+                title={title}
+                minYear={minYear}
+                maxYear={maxYear}
+                selectedDate={selectedDate}
+                onChange={handleChange}
+              />
+            </Card>
+          </AbsoluteContainer>
+        );
+      }
     }
   };
 
   const close = () => {
     setIsOpen(false);
 
-    isMobile ? bottomSheetModalRef.current?.dismiss() : datePickerContext.hidePicker();
+    if (isMobile) {
+      bottomSheetModalRef.current?.dismiss();
+    } else {
+      datePickerContext.hidePicker();
+    }
   };
 
   const toggle = () => {

--- a/src/common-ui/components/DateRangePicker.tsx
+++ b/src/common-ui/components/DateRangePicker.tsx
@@ -42,9 +42,17 @@ const DateRangePicker = (props: DateRangePickerProps) => {
 
   const openDateSelector = () => {
     if (mode.current === "start") {
-      startRef.current?.isPickerOpen() ? startRef.current?.close() : startRef.current?.open();
+      if (startRef.current?.isPickerOpen()) {
+        startRef.current?.close();
+      } else {
+        startRef.current?.open();
+      }
     } else {
-      endRef.current?.isPickerOpen() ? endRef.current?.close() : endRef.current?.open();
+      if (endRef.current?.isPickerOpen()) {
+        endRef.current?.close();
+      } else {
+        endRef.current?.open();
+      }
     }
   };
 

--- a/src/components/GageDetailsChart.tsx
+++ b/src/components/GageDetailsChart.tsx
@@ -339,15 +339,15 @@ export const GageDetailsChart = observer(function GageDetailsChart(props: GageDe
   // Fetch data periodically
   useInterval(
     () => {
-      chartRange.isNow
-        ? gagesStore.fetchDataForGage(
-            gage?.locationId,
-            range.chartStartDate.utc().format(),
-            range.chartEndDate.utc().format(),
-            chartRange.isNow,
-            true
-          )
-        : null;
+      if (chartRange.isNow) {
+        gagesStore.fetchDataForGage(
+          gage?.locationId,
+          range.chartStartDate.utc().format(),
+          range.chartEndDate.utc().format(),
+          chartRange.isNow,
+          true
+        );
+      }
     },
     gage?.locationId && isDataFetched && chartRange.isNow
       ? Config.LIVE_CHART_DATA_REFRESH_INTERVAL

--- a/src/utils/__tests__/useGoBack.test.ts
+++ b/src/utils/__tests__/useGoBack.test.ts
@@ -1,0 +1,55 @@
+import { renderHook, act } from "@testing-library/react-native";
+import { useNavigation, useRouter } from "expo-router";
+import { useGoBack } from "../useGoBack";
+
+jest.mock("expo-router", () => ({
+  useNavigation: jest.fn(),
+  useRouter: jest.fn(),
+}));
+
+describe("useGoBack", () => {
+  it("calls navigation.goBack() when canGoBack returns true", () => {
+    const goBack = jest.fn();
+    const push = jest.fn();
+    (useNavigation as jest.Mock).mockReturnValue({
+      canGoBack: () => true,
+      goBack,
+    });
+    (useRouter as jest.Mock).mockReturnValue({ push });
+
+    const { result } = renderHook(() => useGoBack("/home"));
+    act(() => result.current());
+
+    expect(goBack).toHaveBeenCalledTimes(1);
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("calls router.push with the fallback pathname when canGoBack returns false", () => {
+    const goBack = jest.fn();
+    const push = jest.fn();
+    (useNavigation as jest.Mock).mockReturnValue({
+      canGoBack: () => false,
+      goBack,
+    });
+    (useRouter as jest.Mock).mockReturnValue({ push });
+
+    const { result } = renderHook(() => useGoBack("/user/profile"));
+    act(() => result.current());
+
+    expect(push).toHaveBeenCalledWith({ pathname: "/user/profile" });
+    expect(goBack).not.toHaveBeenCalled();
+  });
+
+  it("returns a stable function reference across re-renders", () => {
+    (useNavigation as jest.Mock).mockReturnValue({
+      canGoBack: () => true,
+      goBack: jest.fn(),
+    });
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+
+    const { result, rerender } = renderHook(() => useGoBack("/home"));
+    const first = result.current;
+    rerender({});
+    expect(result.current).toBe(first);
+  });
+});

--- a/src/utils/useGoBack.ts
+++ b/src/utils/useGoBack.ts
@@ -1,0 +1,15 @@
+import { useCallback } from "react";
+import { useNavigation, useRouter } from "expo-router";
+
+export function useGoBack(fallbackPathname: string): () => void {
+  const navigation = useNavigation();
+  const router = useRouter();
+
+  return useCallback(() => {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+    } else {
+      router.push({ pathname: fallbackPathname });
+    }
+  }, [navigation, router, fallbackPathname]);
+}

--- a/src/utils/useGoBack.ts
+++ b/src/utils/useGoBack.ts
@@ -9,7 +9,7 @@ export function useGoBack(fallbackPathname: string): () => void {
     if (navigation.canGoBack()) {
       navigation.goBack();
     } else {
-      router.push({ pathname: fallbackPathname });
+      router.push({ pathname: fallbackPathname as any });
     }
   }, [navigation, router, fallbackPathname]);
 }


### PR DESCRIPTION
# PR 2 of 3

**Goal:** Resolve the four highest-priority ESLint warning categories — type redeclaration, require-style imports, ternaries used as side-effects, and stale-closure exhaustive-deps — and add unit tests for the two most-testable changes.

## Task 3: Create useGoBack hook with unit tests

Seven screen files repeat the same navigation fallback pattern:
```ts
const goBack = () => {
  navigation.canGoBack() ? navigation.goBack() : router.push({ pathname: ROUTES.X });
};
```
This is flagged by `no-unused-expressions` (ternary used for side effects). Extract it into a testable hook.

**Files:**
- Create: `src/utils/useGoBack.ts`
- Create: `src/utils/__tests__/useGoBack.test.ts`

- [ ] **Step 1: Write the failing tests**

Create `src/utils/__tests__/useGoBack.test.ts`:

```ts
import { renderHook, act } from "@testing-library/react-native";
import { useNavigation, useRouter } from "expo-router";
import { useGoBack } from "../useGoBack";

jest.mock("expo-router", () => ({
  useNavigation: jest.fn(),
  useRouter: jest.fn(),
}));

describe("useGoBack", () => {
  it("calls navigation.goBack() when canGoBack returns true", () => {
    const goBack = jest.fn();
    const push = jest.fn();
    (useNavigation as jest.Mock).mockReturnValue({
      canGoBack: () => true,
      goBack,
    });
    (useRouter as jest.Mock).mockReturnValue({ push });

    const { result } = renderHook(() => useGoBack("/home"));
    act(() => result.current());

    expect(goBack).toHaveBeenCalledTimes(1);
    expect(push).not.toHaveBeenCalled();
  });

  it("calls router.push with the fallback pathname when canGoBack returns false", () => {
    const goBack = jest.fn();
    const push = jest.fn();
    (useNavigation as jest.Mock).mockReturnValue({
      canGoBack: () => false,
      goBack,
    });
    (useRouter as jest.Mock).mockReturnValue({ push });

    const { result } = renderHook(() => useGoBack("/user/profile"));
    act(() => result.current());

    expect(push).toHaveBeenCalledWith({ pathname: "/user/profile" });
    expect(goBack).not.toHaveBeenCalled();
  });

  it("returns a stable function reference across re-renders", () => {
    (useNavigation as jest.Mock).mockReturnValue({
      canGoBack: () => true,
      goBack: jest.fn(),
    });
    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });

    const { result, rerender } = renderHook(() => useGoBack("/home"));
    const first = result.current;
    rerender({});
    expect(result.current).toBe(first);
  });
});
```

- [ ] **Step 2: Run tests to confirm they fail**

```bash
npx jest src/utils/__tests__/useGoBack.test.ts --no-coverage
```

Expected: FAIL — `useGoBack` does not exist yet.

- [ ] **Step 3: Create the hook**

Create `src/utils/useGoBack.ts`:

```ts
import { useCallback } from "react";
import { useNavigation, useRouter } from "expo-router";

export function useGoBack(fallbackPathname: string): () => void {
  const navigation = useNavigation();
  const router = useRouter();

  return useCallback(() => {
    if (navigation.canGoBack()) {
      navigation.goBack();
    } else {
      router.push({ pathname: fallbackPathname });
    }
  }, [navigation, router, fallbackPathname]);
}
```

- [ ] **Step 4: Run tests to confirm they pass**

```bash
npx jest src/utils/__tests__/useGoBack.test.ts --no-coverage
```

Expected: all 3 tests PASS.

- [ ] **Step 5: Commit**

```bash
git add src/utils/useGoBack.ts src/utils/__tests__/useGoBack.test.ts
git commit -m "feat: add useGoBack hook to encapsulate navigation-with-fallback pattern"
```

---

## Task 4: Apply useGoBack to 7 screen files

Replace the inline `goBack` ternary pattern in each screen with a call to `useGoBack`. In each file: remove the `useNavigation` and `useRouter` calls used only for the `goBack` function (leave any other usages), import `useGoBack`, and call it with the same fallback route.

**Files:**
- Modify: `app/(root)/gage/[id].tsx`
- Modify: `app/(root)/forecast/[...id].tsx`
- Modify: `app/(root)/user/createpassword.tsx`
- Modify: `app/(root)/user/profile.tsx`
- Modify: `app/(root)/user/resetpassword.tsx`
- Modify: `app/(root)/user/setpassword.tsx`
- Modify: `app/(root)/user/verifyPhoneNumber.tsx`

For each file below, the change is:
1. Add `import { useGoBack } from "@utils/useGoBack";`
2. Remove `useNavigation` and `useRouter` from imports **only if** they are not used elsewhere in that file (check the full file before removing)
3. Remove the `const navigation = useNavigation();` and `const router = useRouter();` lines **only if** those variables are not used elsewhere
4. Replace the `goBack` function body

Each step below follows the same pattern: add `import { useGoBack } from "@utils/useGoBack";`, replace the `goBack` function body, and remove the `useNavigation`/`useRouter` calls **only if no other code in that file uses them** (read the full file before removing).

- [ ] **Step 1: Update `app/(root)/gage/[id].tsx`**

`router` is used for other navigations in this file — keep the `useRouter` import and its const. `useNavigation` is only used for `goBack` — remove it.

Replace:
```ts
const navigation = useNavigation();  // remove this line
const goBack = () => {
  navigation.canGoBack() ? navigation.goBack() : router.push({ pathname: ROUTES.Home });
};
```

With:
```ts
const goBack = useGoBack(ROUTES.Home);
```

Remove `useNavigation` from the `expo-router` import line. Add `import { useGoBack } from "@utils/useGoBack";`.

- [ ] **Step 2: Update `app/(root)/forecast/[...id].tsx`**

`goBack` is at line 69. Read the file to determine if `router` or `navigation` are used elsewhere, then remove only what becomes unused.

Replace:
```ts
const goBack = () => {
  navigation.canGoBack() ? navigation.goBack() : router.push({ pathname: ROUTES.Forecast });
};
```

With:
```ts
const goBack = useGoBack(ROUTES.Forecast);
```

Add `import { useGoBack } from "@utils/useGoBack";`. Remove `useNavigation` and `useRouter` from the `expo-router` import only for whichever are now unused.

- [ ] **Step 3: Update `app/(root)/user/createpassword.tsx`**

`goBack` is at line 39. Read the file first — if `router` and `navigation` are only used for `goBack`, remove both their consts and imports.

Replace:
```ts
const goBack = () => {
  navigation.canGoBack() ? navigation.goBack() : router.push({ pathname: ROUTES.UserProfile });
};
```

With:
```ts
const goBack = useGoBack(ROUTES.UserProfile);
```

- [ ] **Step 4: Update `app/(root)/user/profile.tsx`**

`goBack` is at line 117. `router` is used at lines ~106, ~110, ~114 for other navigations — keep `useRouter` and its const. `useNavigation` is only used for `goBack` — remove it.

Replace:
```ts
const navigation = useNavigation();  // remove this line
const goBack = () => {
  navigation.canGoBack() ? navigation.goBack() : router.push({ pathname: ROUTES.About });
};
```

With:
```ts
const goBack = useGoBack(ROUTES.About);
```

Remove `useNavigation` from the `expo-router` import line.

- [ ] **Step 5: Update `app/(root)/user/resetpassword.tsx`**

`goBack` is at line 62. Read the file to check for other uses of `router`/`navigation`, then remove what becomes unused.

Replace:
```ts
const goBack = () => {
  navigation.canGoBack() ? navigation.goBack() : router.push({ pathname: ROUTES.UserProfile });
};
```

With:
```ts
const goBack = useGoBack(ROUTES.UserProfile);
```

- [ ] **Step 6: Update `app/(root)/user/setpassword.tsx`**

`goBack` is at line 41. Same pattern as above.

Replace:
```ts
const goBack = () => {
  navigation.canGoBack() ? navigation.goBack() : router.push({ pathname: ROUTES.UserProfile });
};
```

With:
```ts
const goBack = useGoBack(ROUTES.UserProfile);
```

- [ ] **Step 7: Update `app/(root)/user/verifyPhoneNumber.tsx`**

`goBack` is at line 74. Same pattern.

Replace:
```ts
const goBack = () => {
  navigation.canGoBack() ? navigation.goBack() : router.push({ pathname: ROUTES.UserAlerts });
};
```

With:
```ts
const goBack = useGoBack(ROUTES.UserAlerts);
```

- [ ] **Step 8: Type-check and verify lint**

```bash
npx tsc --noEmit
npx eslint "app/(root)" --ext .tsx
```

Expected: no new TypeScript errors, the 7 `no-unused-expressions` warnings from goBack are gone. If any `useNavigation` / `useRouter` imports were left in but are now unused, ESLint will surface them — clean those up before committing.

- [ ] **Step 9: Commit**

```bash
git add "app/(root)/gage/[id].tsx" "app/(root)/forecast/[...id].tsx" \
  "app/(root)/user/createpassword.tsx" "app/(root)/user/profile.tsx" \
  "app/(root)/user/resetpassword.tsx" "app/(root)/user/setpassword.tsx" \
  "app/(root)/user/verifyPhoneNumber.tsx"
git commit -m "fix: replace inline goBack ternaries with useGoBack hook across 7 screens"
```

---

## Task 5: Fix remaining ternary side-effects

Three more files use ternaries as side-effect expressions (not in screen navigation). Convert each to `if`/`else`.

**Files:**
- Modify: `src/common-ui/components/DatePicker.tsx` (lines 314, 339)
- Modify: `src/common-ui/components/DateRangePicker.tsx` (lines 45, 47)
- Modify: `src/components/GageDetailsChart.tsx` (line 342)

- [ ] **Step 1: Fix DatePicker.tsx line 314**

Change:
```tsx
isMobile
  ? bottomSheetModalRef.current?.present()
  : datePickerContext.showPicker(
      <AbsoluteContainer
        sticks={["left"]}
        zIndex={10}
        top={pageY + Spacing.larger}
        left={leftOffset}>
        <Card width={PICKER_WIDTH} height={PICKER_HEIGHT}>
          <DatePicker
            title={title}
            minYear={minYear}
            maxYear={maxYear}
            selectedDate={selectedDate}
            onChange={handleChange}
          />
        </Card>
      </AbsoluteContainer>
    );
```

To:
```tsx
if (isMobile) {
  bottomSheetModalRef.current?.present();
} else {
  datePickerContext.showPicker(
    <AbsoluteContainer
      sticks={["left"]}
      zIndex={10}
      top={pageY + Spacing.larger}
      left={leftOffset}>
      <Card width={PICKER_WIDTH} height={PICKER_HEIGHT}>
        <DatePicker
          title={title}
          minYear={minYear}
          maxYear={maxYear}
          selectedDate={selectedDate}
          onChange={handleChange}
        />
      </Card>
    </AbsoluteContainer>
  );
}

- [ ] **Step 2: Fix DatePicker.tsx line 339**

Change:
```ts
isMobile ? bottomSheetModalRef.current?.dismiss() : datePickerContext.hidePicker();
```

To:
```ts
if (isMobile) {
  bottomSheetModalRef.current?.dismiss();
} else {
  datePickerContext.hidePicker();
}
```

- [ ] **Step 3: Fix DateRangePicker.tsx lines 45 and 47**

Change:
```ts
startRef.current?.isPickerOpen() ? startRef.current?.close() : startRef.current?.open();
// ...
endRef.current?.isPickerOpen() ? endRef.current?.close() : endRef.current?.open();
```

To:
```ts
if (startRef.current?.isPickerOpen()) {
  startRef.current?.close();
} else {
  startRef.current?.open();
}
// ...
if (endRef.current?.isPickerOpen()) {
  endRef.current?.close();
} else {
  endRef.current?.open();
}
```

- [ ] **Step 4: Fix GageDetailsChart.tsx line 342**

The `useInterval` callback at line 341 uses a ternary as a statement. Change:

```ts
useInterval(
  () => {
    chartRange.isNow
      ? gagesStore.fetchDataForGage(
          gage?.locationId,
          range.chartStartDate.utc().format(),
          range.chartEndDate.utc().format(),
          chartRange.isNow,
          true
        )
      : null;
  },
  ...
)
```

To:

```ts
useInterval(
  () => {
    if (chartRange.isNow) {
      gagesStore.fetchDataForGage(
        gage?.locationId,
        range.chartStartDate.utc().format(),
        range.chartEndDate.utc().format(),
        chartRange.isNow,
        true
      );
    }
  },
  ...
)
```

- [ ] **Step 5: Type-check and verify lint**

```bash
npx tsc --noEmit
npx eslint src/common-ui/components/DatePicker.tsx src/common-ui/components/DateRangePicker.tsx src/components/GageDetailsChart.tsx
```

Expected: the `no-unused-expressions` warnings in these files are gone.

- [ ] **Step 6: Commit**

```bash
git add src/common-ui/components/DatePicker.tsx \
  src/common-ui/components/DateRangePicker.tsx \
  src/components/GageDetailsChart.tsx
git commit -m "fix: convert ternary side-effects to if/else in DatePicker, DateRangePicker, GageDetailsChart"
```

---