### PR TITLE
Fix/date picker

### DIFF
--- a/src/common-ui/components/DatePicker.tsx
+++ b/src/common-ui/components/DatePicker.tsx
@@ -313,11 +313,9 @@ const DatePickerComponent = React.forwardRef((props: DatePickerProps, ref) => {
 
       const offsetLeft = pageX - Spacing.medium;
       const leftOffset =
-        width < 768
+        width < Spacing.tabletWidth
           ? (width - PICKER_WIDTH) / 2
-          : offsetLeft + PICKER_WIDTH > width
-          ? width - PICKER_WIDTH - Spacing.small
-          : offsetLeft;
+          : Math.min(offsetLeft, width - PICKER_WIDTH - Spacing.small);
 
       setIsOpen(true);
 

--- a/src/common-ui/components/DatePicker.tsx
+++ b/src/common-ui/components/DatePicker.tsx
@@ -283,6 +283,13 @@ const DatePickerComponent = React.forwardRef((props: DatePickerProps, ref) => {
   const datePickerContext = useDatePicker();
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
+  // Sync local isOpen when picker is dismissed externally (navigation, range change, etc.)
+  useEffect(() => {
+    if (!datePickerContext.isVisible) {
+      setIsOpen(false);
+    }
+  }, [datePickerContext.isVisible]);
+
   const handleChange = (date: Dayjs) => {
     close();
     onChange?.(date);

--- a/src/common-ui/components/DatePicker.tsx
+++ b/src/common-ui/components/DatePicker.tsx
@@ -6,11 +6,10 @@ import { ScrollView } from "react-native-gesture-handler";
 import { SmallTitle, RegularText } from "./Text";
 import { Spacing } from "@common-ui/constants/spacing";
 import { If, Ternary } from "./Conditional";
-import { Pressable, View, ViewStyle, useWindowDimensions } from "react-native";
+import { Platform, Pressable, View, ViewStyle, useWindowDimensions } from "react-native";
 import { Colors } from "@common-ui/constants/colors";
 import { SegmentControl } from "./SegmentControl";
 import { Card } from "./Card";
-import { useResponsive } from "@common-ui/utils/responsive";
 import { BottomSheetModal } from "@gorhom/bottom-sheet";
 import { useDatePicker } from "@common-ui/contexts/DatePickerContext";
 import { measure, useAnimatedRef } from "react-native-reanimated";
@@ -271,7 +270,7 @@ const DatePicker = (props: DatePickerProps) => {
 // eslint-disable-next-line react/display-name
 const DatePickerComponent = React.forwardRef((props: DatePickerProps, ref) => {
   const { minYear = 1990, maxYear = localDayJs().year(), selectedDate, title, onChange } = props;
-  const { isMobile } = useResponsive();
+  const isNativeMobile = Platform.OS !== "web";
 
   const { width } = useWindowDimensions();
 
@@ -296,7 +295,7 @@ const DatePickerComponent = React.forwardRef((props: DatePickerProps, ref) => {
   };
 
   useEffect(() => {
-    if (isMobile) {
+    if (isNativeMobile) {
       return;
     }
 
@@ -314,11 +313,15 @@ const DatePickerComponent = React.forwardRef((props: DatePickerProps, ref) => {
 
       const offsetLeft = pageX - Spacing.medium;
       const leftOffset =
-        offsetLeft + PICKER_WIDTH > width ? width - PICKER_WIDTH - Spacing.small : offsetLeft;
+        width < 768
+          ? (width - PICKER_WIDTH) / 2
+          : offsetLeft + PICKER_WIDTH > width
+          ? width - PICKER_WIDTH - Spacing.small
+          : offsetLeft;
 
       setIsOpen(true);
 
-      if (isMobile) {
+      if (isNativeMobile) {
         bottomSheetModalRef.current?.present();
       } else {
         datePickerContext.showPicker(
@@ -345,7 +348,7 @@ const DatePickerComponent = React.forwardRef((props: DatePickerProps, ref) => {
   const close = () => {
     setIsOpen(false);
 
-    if (isMobile) {
+    if (isNativeMobile) {
       bottomSheetModalRef.current?.dismiss();
     } else {
       datePickerContext.hidePicker();

--- a/src/common-ui/components/DatePicker.tsx
+++ b/src/common-ui/components/DatePicker.tsx
@@ -10,7 +10,7 @@ import { Platform, Pressable, View, ViewStyle, useWindowDimensions } from "react
 import { Colors } from "@common-ui/constants/colors";
 import { SegmentControl } from "./SegmentControl";
 import { Card } from "./Card";
-import { BottomSheetModal } from "@gorhom/bottom-sheet";
+import { BottomSheetModal, BottomSheetView } from "@gorhom/bottom-sheet";
 import { useDatePicker } from "@common-ui/contexts/DatePickerContext";
 import { measure, useAnimatedRef } from "react-native-reanimated";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
@@ -381,25 +381,18 @@ const DatePickerComponent = React.forwardRef((props: DatePickerProps, ref) => {
       <View ref={pickerRef}>
         <RegularText text={formattedDate} />
       </View>
-      <BottomSheetModal
-        index={0}
-        ref={bottomSheetModalRef}
-        snapPoints={["40%"]}
-        style={$bottomSheetStyleMobile}>
-        <Cell
-          flex
-          height={170}
-          horizontal={Spacing.small}
-          top={Spacing.medium}
-          bottom={Spacing.extraLarge}>
-          <DatePicker
-            title={title}
-            minYear={minYear}
-            maxYear={maxYear}
-            selectedDate={selectedDate}
-            onChange={handleChange}
-          />
-        </Cell>
+      <BottomSheetModal index={0} ref={bottomSheetModalRef} style={$bottomSheetStyleMobile}>
+        <BottomSheetView>
+          <Cell horizontal={Spacing.small} top={Spacing.medium} bottom={Spacing.extraLarge}>
+            <DatePicker
+              title={title}
+              minYear={minYear}
+              maxYear={maxYear}
+              selectedDate={selectedDate}
+              onChange={handleChange}
+            />
+          </Cell>
+        </BottomSheetView>
       </BottomSheetModal>
     </>
   );

--- a/src/common-ui/components/DateRangePicker.tsx
+++ b/src/common-ui/components/DateRangePicker.tsx
@@ -34,9 +34,17 @@ const DateRangePicker = (props: DateRangePickerProps) => {
   const startRef = useRef(null);
   const endRef = useRef(null);
 
-  const start = useRef(startDate);
-  const end = useRef(endDate);
+  const [start, setStart] = useState<Dayjs>(startDate);
+  const [end, setEnd] = useState<Dayjs>(endDate);
   const mode = useRef<"start" | "end">("start");
+
+  useEffect(() => {
+    setStart(startDate);
+  }, [startDate.valueOf()]);
+
+  useEffect(() => {
+    setEnd(endDate);
+  }, [endDate.valueOf()]);
 
   const [pickedStart, setPickedStart] = useState<boolean>(false);
 
@@ -67,7 +75,7 @@ const DateRangePicker = (props: DateRangePickerProps) => {
       dateStart = today.subtract(1, "day");
     }
 
-    start.current = dateStart;
+    setStart(dateStart);
     openDateSelector();
   };
 
@@ -80,17 +88,17 @@ const DateRangePicker = (props: DateRangePickerProps) => {
       dateEnd = today;
     }
 
-    const daysDiff = Math.abs(dateEnd.clone().diff(start.current, "day"));
+    const daysDiff = Math.abs(dateEnd.clone().diff(start, "day"));
 
     mode.current = "start";
 
     if (daysDiff > maxRange) {
-      dateEnd = start.current.clone().add(maxRange, "day");
+      dateEnd = start.clone().add(maxRange, "day");
     }
 
-    end.current = dateEnd;
+    setEnd(dateEnd);
 
-    onChange(start.current, dateEnd);
+    onChange(start, dateEnd);
   };
 
   return (
@@ -104,7 +112,7 @@ const DateRangePicker = (props: DateRangePickerProps) => {
       <DatePicker
         title={t("datePicker.startDate")}
         ref={startRef}
-        selectedDate={start.current}
+        selectedDate={start}
         minYear={minYear}
         maxYear={maxYear}
         onChange={handleStartDateChange}
@@ -115,7 +123,7 @@ const DateRangePicker = (props: DateRangePickerProps) => {
       <DatePicker
         title={t("datePicker.endDate")}
         ref={endRef}
-        selectedDate={end.current}
+        selectedDate={end}
         minYear={minYear}
         maxYear={maxYear}
         onChange={handleEndDateChange}

--- a/src/common-ui/components/__tests__/DatePicker.native.test.tsx
+++ b/src/common-ui/components/__tests__/DatePicker.native.test.tsx
@@ -1,0 +1,166 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+// src/common-ui/components/__tests__/DatePicker.native.test.tsx
+import React from "react";
+import { render, act } from "@testing-library/react-native";
+import dayjs from "dayjs";
+import DatePickerComponent from "../DatePicker";
+
+jest.mock("react-native/Libraries/Utilities/Platform", () => ({
+  default: {
+    OS: "ios",
+    select: (obj: any) => obj.ios ?? obj.native ?? obj.default,
+    isTesting: true,
+  },
+  OS: "ios",
+  select: (obj: any) => obj.ios ?? obj.native ?? obj.default,
+  isTesting: true,
+}));
+
+jest.mock("@common-ui/utils/responsive", () => ({
+  useResponsive: () => ({ isMobile: true }),
+  isMobile: true,
+  isIOS: true,
+  isAndroid: false,
+}));
+
+jest.mock("react-native-reanimated", () => ({
+  measure: jest.fn(() => null),
+  useAnimatedRef: () => ({ current: null }),
+  default: { createAnimatedComponent: (c: any) => c },
+}));
+
+const mockPresent = jest.fn();
+const mockDismiss = jest.fn();
+let bottomSheetViewRendered = false;
+jest.mock("@gorhom/bottom-sheet", () => {
+  const ReactModule = require("react");
+  const MockBottomSheetModal = ReactModule.forwardRef(({ children }: any, ref: any) => {
+    ReactModule.useImperativeHandle(ref, () => ({
+      present: mockPresent,
+      dismiss: mockDismiss,
+    }));
+    return ReactModule.createElement(ReactModule.Fragment, null, children);
+  });
+  MockBottomSheetModal.displayName = "MockBottomSheetModal";
+  const MockBottomSheetView = ({ children }: any) => {
+    bottomSheetViewRendered = true;
+    return ReactModule.createElement(ReactModule.Fragment, null, children);
+  };
+  return {
+    BottomSheetModal: MockBottomSheetModal,
+    BottomSheetView: MockBottomSheetView,
+  };
+});
+
+const mockShowPicker = jest.fn();
+const mockHidePicker = jest.fn();
+jest.mock("@common-ui/contexts/DatePickerContext", () => ({
+  useDatePicker: () => ({
+    isVisible: false,
+    showPicker: mockShowPicker,
+    hidePicker: mockHidePicker,
+  }),
+}));
+
+jest.mock("@common-ui/contexts/LocaleContext", () => ({
+  useLocale: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock("react-native-gesture-handler", () => {
+  const RN = require("react-native");
+  return {
+    ScrollView: RN.ScrollView,
+    GestureHandlerRootView: RN.View,
+  };
+});
+
+jest.mock("@common-ui/components/Text", () => ({
+  SmallTitle: () => null,
+  RegularText: () => null,
+}));
+
+jest.mock("@common-ui/components/Common", () => {
+  const ReactModule = require("react");
+  const Pass = ({ children }: any) =>
+    ReactModule.createElement(ReactModule.Fragment, null, children ?? null);
+  return {
+    AbsoluteContainer: Pass,
+    Cell: Pass,
+    Row: Pass,
+    Separator: () => null,
+  };
+});
+
+jest.mock("@common-ui/components/Conditional", () => {
+  const ReactModule = require("react");
+  return {
+    If: ({ condition, children }: any) =>
+      condition ? ReactModule.createElement(ReactModule.Fragment, null, children) : null,
+    Ternary: ({ condition, children }: any) => {
+      const arr = ReactModule.Children.toArray(children);
+      return condition ? arr[0] ?? null : arr[1] ?? null;
+    },
+  };
+});
+
+jest.mock("@common-ui/components/SegmentControl", () => ({
+  SegmentControl: () => null,
+}));
+
+jest.mock("@common-ui/components/Card", () => {
+  const ReactModule = require("react");
+  const Pass = ({ children }: any) =>
+    ReactModule.createElement(ReactModule.Fragment, null, children ?? null);
+  return { Card: Pass };
+});
+
+jest.mock("@services/localDayJs", () => {
+  const dayjsModule = require("dayjs");
+  return Object.assign(dayjsModule, { tz: dayjsModule });
+});
+
+const selectedDate = dayjs("2026-04-01");
+
+describe("DatePickerComponent on native iOS", () => {
+  beforeEach(() => {
+    mockShowPicker.mockClear();
+    mockHidePicker.mockClear();
+    mockPresent.mockClear();
+    mockDismiss.mockClear();
+    bottomSheetViewRendered = false;
+  });
+
+  it("renders BottomSheetView as a child of BottomSheetModal", () => {
+    const ref = React.createRef<any>();
+    render(<DatePickerComponent ref={ref} selectedDate={selectedDate} onChange={jest.fn()} />);
+
+    expect(bottomSheetViewRendered).toBe(true);
+  });
+
+  it("calls BottomSheetModal.present() when opened — not the popover showPicker()", () => {
+    const ref = React.createRef<any>();
+    render(<DatePickerComponent ref={ref} selectedDate={selectedDate} onChange={jest.fn()} />);
+
+    act(() => {
+      ref.current?.open();
+    });
+
+    expect(mockPresent).toHaveBeenCalledTimes(1);
+    expect(mockShowPicker).not.toHaveBeenCalled();
+  });
+
+  it("calls BottomSheetModal.dismiss() when closed — not the popover hidePicker()", () => {
+    const ref = React.createRef<any>();
+    render(<DatePickerComponent ref={ref} selectedDate={selectedDate} onChange={jest.fn()} />);
+
+    act(() => {
+      ref.current?.open();
+    });
+    act(() => {
+      ref.current?.close();
+    });
+
+    expect(mockDismiss).toHaveBeenCalledTimes(1);
+    expect(mockHidePicker).not.toHaveBeenCalled();
+  });
+});

--- a/src/common-ui/components/__tests__/DatePicker.test.tsx
+++ b/src/common-ui/components/__tests__/DatePicker.test.tsx
@@ -1,0 +1,150 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+// src/common-ui/components/__tests__/DatePicker.test.tsx
+import React from "react";
+import { render, act } from "@testing-library/react-native";
+import dayjs from "dayjs";
+import DatePickerComponent from "../DatePicker";
+
+jest.mock("react-native/Libraries/Utilities/Platform", () => ({
+  default: {
+    OS: "web",
+    select: (obj: any) => obj.web ?? obj.default,
+    isTesting: true,
+  },
+  OS: "web",
+  select: (obj: any) => obj.web ?? obj.default,
+  isTesting: true,
+}));
+
+jest.mock("@common-ui/utils/responsive", () => ({
+  useResponsive: () => ({ isMobile: true }), // mobile viewport, web platform
+  isMobile: false,
+  isIOS: false,
+  isAndroid: false,
+}));
+
+jest.mock("react-native-reanimated", () => ({
+  measure: jest.fn(() => ({ pageX: 50, pageY: 100, x: 50, y: 100, width: 200, height: 40 })),
+  useAnimatedRef: () => ({ current: null }),
+  default: { createAnimatedComponent: (c: any) => c },
+}));
+
+const mockPresent = jest.fn();
+const mockDismiss = jest.fn();
+jest.mock("@gorhom/bottom-sheet", () => {
+  const ReactModule = require("react");
+  const MockBottomSheetModal = ReactModule.forwardRef((_props: any, ref: any) => {
+    ReactModule.useImperativeHandle(ref, () => ({
+      present: mockPresent,
+      dismiss: mockDismiss,
+    }));
+    return null;
+  });
+  MockBottomSheetModal.displayName = "MockBottomSheetModal";
+  return { BottomSheetModal: MockBottomSheetModal };
+});
+
+const mockShowPicker = jest.fn();
+const mockHidePicker = jest.fn();
+jest.mock("@common-ui/contexts/DatePickerContext", () => ({
+  useDatePicker: () => ({
+    isVisible: false,
+    showPicker: mockShowPicker,
+    hidePicker: mockHidePicker,
+  }),
+}));
+
+jest.mock("@common-ui/contexts/LocaleContext", () => ({
+  useLocale: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock("react-native-gesture-handler", () => {
+  const RN = require("react-native");
+  return {
+    ScrollView: RN.ScrollView,
+    GestureHandlerRootView: RN.View,
+  };
+});
+
+jest.mock("@common-ui/components/Text", () => ({
+  SmallTitle: () => null,
+  RegularText: () => null,
+}));
+
+jest.mock("@common-ui/components/Common", () => {
+  const ReactModule = require("react");
+  const Pass = ({ children }: any) =>
+    ReactModule.createElement(ReactModule.Fragment, null, children ?? null);
+  return {
+    AbsoluteContainer: Pass,
+    Cell: Pass,
+    Row: Pass,
+    Separator: () => null,
+  };
+});
+
+jest.mock("@common-ui/components/Conditional", () => {
+  const ReactModule = require("react");
+  return {
+    If: ({ condition, children }: any) =>
+      condition ? ReactModule.createElement(ReactModule.Fragment, null, children) : null,
+    Ternary: ({ condition, children }: any) => {
+      const arr = ReactModule.Children.toArray(children);
+      return condition ? arr[0] ?? null : arr[1] ?? null;
+    },
+  };
+});
+
+jest.mock("@common-ui/components/SegmentControl", () => ({
+  SegmentControl: () => null,
+}));
+
+jest.mock("@common-ui/components/Card", () => {
+  const ReactModule = require("react");
+  const Pass = ({ children }: any) =>
+    ReactModule.createElement(ReactModule.Fragment, null, children ?? null);
+  return { Card: Pass };
+});
+
+jest.mock("@services/localDayJs", () => {
+  const dayjsModule = require("dayjs");
+  return Object.assign(dayjsModule, { tz: dayjsModule });
+});
+
+const selectedDate = dayjs("2026-04-01");
+
+describe("DatePickerComponent on web with mobile viewport", () => {
+  beforeEach(() => {
+    mockShowPicker.mockClear();
+    mockHidePicker.mockClear();
+    mockPresent.mockClear();
+    mockDismiss.mockClear();
+  });
+
+  it("calls showPicker (popover) when opened — not BottomSheetModal.present()", () => {
+    const ref = React.createRef<any>();
+    render(<DatePickerComponent ref={ref} selectedDate={selectedDate} onChange={jest.fn()} />);
+
+    act(() => {
+      ref.current?.open();
+    });
+
+    expect(mockShowPicker).toHaveBeenCalledTimes(1);
+    expect(mockPresent).not.toHaveBeenCalled();
+  });
+
+  it("calls hidePicker (popover) when closed — not BottomSheetModal.dismiss()", () => {
+    const ref = React.createRef<any>();
+    render(<DatePickerComponent ref={ref} selectedDate={selectedDate} onChange={jest.fn()} />);
+
+    act(() => {
+      ref.current?.open();
+    });
+    act(() => {
+      ref.current?.close();
+    });
+
+    expect(mockHidePicker).toHaveBeenCalledTimes(1);
+    expect(mockDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/src/common-ui/components/__tests__/DateRangePicker.test.tsx
+++ b/src/common-ui/components/__tests__/DateRangePicker.test.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { render, act } from "@testing-library/react-native";
+import dayjs, { Dayjs } from "dayjs";
+import DateRangePicker from "../DateRangePicker";
+
+jest.mock("@common-ui/contexts/LocaleContext", () => ({
+  useLocale: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("../Icon", () => () => null);
+
+jest.mock("../Text", () => ({
+  RegularText: () => null,
+}));
+
+jest.mock("../Common", () => {
+  const React = require("react");
+  return {
+    Cell: ({ children }: any) => React.createElement(React.Fragment, null, children),
+  };
+});
+
+// Capture onChange callbacks keyed by picker title so tests can invoke them
+const pickerRegistry: Record<string, (date: Dayjs) => void> = {};
+
+jest.mock("../DatePicker", () => {
+  const React = require("react");
+  const MockDatePicker = React.forwardRef((props: any, ref: any) => {
+    const key = props.title ?? "unknown";
+    pickerRegistry[key] = props.onChange;
+    React.useImperativeHandle(ref, () => ({
+      open: jest.fn(),
+      close: jest.fn(),
+      isPickerOpen: jest.fn(() => false),
+    }));
+    return React.createElement(
+      "Text",
+      { testID: `date-picker-${key}` },
+      props.selectedDate?.format("MM/DD/YYYY") ?? ""
+    );
+  });
+  MockDatePicker.displayName = "MockDatePicker";
+  return {
+    __esModule: true,
+    default: MockDatePicker,
+  };
+});
+
+const jan1 = dayjs("2022-01-01");
+const jan31 = dayjs("2022-01-31");
+
+describe("DateRangePicker", () => {
+  it("renders the formatted start and end dates from initial props", () => {
+    const { getByTestId } = render(
+      <DateRangePicker startDate={jan1} endDate={jan31} onChange={jest.fn()} />
+    );
+
+    expect(getByTestId("date-picker-datePicker.startDate").props.children).toBe("01/01/2022");
+    expect(getByTestId("date-picker-datePicker.endDate").props.children).toBe("01/31/2022");
+  });
+
+  it("updates the displayed start date when startDate prop changes externally", () => {
+    const onChange = jest.fn();
+    const { rerender, getByTestId } = render(
+      <DateRangePicker startDate={jan1} endDate={jan31} onChange={onChange} />
+    );
+
+    rerender(
+      <DateRangePicker startDate={dayjs("2021-11-15")} endDate={jan31} onChange={onChange} />
+    );
+
+    expect(getByTestId("date-picker-datePicker.startDate").props.children).toBe("11/15/2021");
+  });
+
+  it("updates the displayed end date when endDate prop changes externally", () => {
+    const onChange = jest.fn();
+    const { rerender, getByTestId } = render(
+      <DateRangePicker startDate={jan1} endDate={jan31} onChange={onChange} />
+    );
+
+    rerender(
+      <DateRangePicker startDate={jan1} endDate={dayjs("2022-03-15")} onChange={onChange} />
+    );
+
+    expect(getByTestId("date-picker-datePicker.endDate").props.children).toBe("03/15/2022");
+  });
+
+  it("calls onChange with selected start and end dates after user picks both", () => {
+    const onChange = jest.fn();
+    render(<DateRangePicker startDate={jan1} endDate={jan31} onChange={onChange} />);
+
+    act(() => {
+      pickerRegistry["datePicker.startDate"]?.(dayjs("2022-06-01"));
+    });
+    act(() => {
+      pickerRegistry["datePicker.endDate"]?.(dayjs("2022-06-30"));
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [calledStart, calledEnd] = onChange.mock.calls[0] as [Dayjs, Dayjs];
+    expect(calledStart.format("YYYY-MM-DD")).toBe("2022-06-01");
+    expect(calledEnd.format("YYYY-MM-DD")).toBe("2022-06-30");
+  });
+
+  it("clamps end date to start + maxRange days when selection exceeds the limit", () => {
+    const onChange = jest.fn();
+    render(<DateRangePicker startDate={jan1} endDate={jan31} maxRange={30} onChange={onChange} />);
+
+    act(() => {
+      pickerRegistry["datePicker.startDate"]?.(dayjs("2022-06-01"));
+    });
+    act(() => {
+      // 59 days after 2022-06-01 — exceeds maxRange=30, should clamp to 2022-07-01
+      pickerRegistry["datePicker.endDate"]?.(dayjs("2022-07-30"));
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [, calledEnd] = onChange.mock.calls[0] as [Dayjs, Dayjs];
+    expect(calledEnd.format("YYYY-MM-DD")).toBe("2022-07-01");
+  });
+});

--- a/src/common-ui/contexts/DatePickerContext.tsx
+++ b/src/common-ui/contexts/DatePickerContext.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { usePathname } from "expo-router";
 
 type DatePickerContextType = {
   isVisible: boolean;
@@ -18,15 +19,21 @@ export const DatePickerProvider = ({ children }: { children: React.ReactNode }) 
   const [isVisible, setIsVisible] = React.useState(false);
   const [content, setContent] = React.useState<React.ReactNode>(null);
 
-  const showPicker = (content: React.ReactNode) => {
-    setContent(content);
-    setIsVisible(true);
-  };
+  const pathname = usePathname();
 
-  const hidePicker = () => {
+  const hidePicker = React.useCallback(() => {
     setIsVisible(false);
     setContent(null);
-  };
+  }, []);
+
+  const showPicker = React.useCallback((newContent: React.ReactNode) => {
+    setContent(newContent);
+    setIsVisible(true);
+  }, []);
+
+  React.useEffect(() => {
+    hidePicker();
+  }, [pathname, hidePicker]);
 
   return (
     <DatePickerContext.Provider value={{ isVisible, showPicker, hidePicker }}>

--- a/src/common-ui/contexts/__tests__/DatePickerContext.test.tsx
+++ b/src/common-ui/contexts/__tests__/DatePickerContext.test.tsx
@@ -1,0 +1,75 @@
+// src/common-ui/contexts/__tests__/DatePickerContext.test.tsx
+import React from "react";
+import { render, act, fireEvent } from "@testing-library/react-native";
+import { View, Text, Button } from "react-native";
+import { DatePickerProvider, useDatePicker } from "../DatePickerContext";
+
+let mockPathname = "/gage/USGS-NF10";
+
+jest.mock("expo-router", () => ({
+  usePathname: () => mockPathname,
+}));
+
+const TestConsumer = () => {
+  const { isVisible, showPicker } = useDatePicker();
+  return (
+    <View>
+      <Text testID="visible">{String(isVisible)}</Text>
+      <Button testID="show" title="Show" onPress={() => showPicker(<Text>picker content</Text>)} />
+    </View>
+  );
+};
+
+const renderWithProvider = () =>
+  render(
+    <DatePickerProvider>
+      <TestConsumer />
+    </DatePickerProvider>
+  );
+
+describe("DatePickerProvider — navigation dismissal", () => {
+  beforeEach(() => {
+    mockPathname = "/gage/USGS-NF10";
+  });
+
+  it("hides the picker when the pathname changes (navigating away)", () => {
+    const { getByTestId, rerender } = renderWithProvider();
+
+    act(() => {
+      fireEvent.press(getByTestId("show"));
+    });
+
+    expect(getByTestId("visible").props.children).toBe("true");
+
+    mockPathname = "/forecast";
+    act(() => {
+      rerender(
+        <DatePickerProvider>
+          <TestConsumer />
+        </DatePickerProvider>
+      );
+    });
+
+    expect(getByTestId("visible").props.children).toBe("false");
+  });
+
+  it("does not hide the picker when the pathname stays the same", () => {
+    const { getByTestId, rerender } = renderWithProvider();
+
+    act(() => {
+      fireEvent.press(getByTestId("show"));
+    });
+
+    expect(getByTestId("visible").props.children).toBe("true");
+
+    act(() => {
+      rerender(
+        <DatePickerProvider>
+          <TestConsumer />
+        </DatePickerProvider>
+      );
+    });
+
+    expect(getByTestId("visible").props.children).toBe("true");
+  });
+});

--- a/src/components/GageDetailsChart.tsx
+++ b/src/components/GageDetailsChart.tsx
@@ -354,9 +354,11 @@ export const GageDetailsChart = observer(function GageDetailsChart(props: GageDe
       : null
   );
 
-  // Fetch data on mount but first wait for main data to be fetched
+  // Fetch data on mount but first wait for main data to be fetched.
+  // Skip if already in historical mode — the dateRange effect handles that case
+  // and re-running this would race against an in-progress historical fetch.
   useEffect(() => {
-    if (gage?.locationId && isDataFetched) {
+    if (gage?.locationId && isDataFetched && chartRange.isNow) {
       gagesStore.fetchDataForGage(
         gage?.locationId,
         chartRange.chartStartDate.utc().format(),

--- a/src/components/GageDetailsChart.tsx
+++ b/src/components/GageDetailsChart.tsx
@@ -370,24 +370,24 @@ export const GageDetailsChart = observer(function GageDetailsChart(props: GageDe
   }, [gage?.locationId, isDataFetched]);
 
   useEffect(() => {
-    if (dateRange.from && dateRange.to) {
-      // Convert to Dayjs objects
-      // @ts-ignore
-      const fromDayjs = localDayJs.tz(dateRange.from).startOf("day");
-      // @ts-ignore
-      const toDayjs = localDayJs.tz(dateRange.to).endOf("day");
-
-      // Update chart range
-      chartRange.changeDates(fromDayjs, toDayjs);
-
-      setRange({
-        chartStartDate: chartRange.chartStartDate,
-        chartEndDate: chartRange.chartEndDate,
-      });
-
-      refreshData(chartRange.chartStartDate.utc().format(), chartRange.chartEndDate.utc().format());
+    if (!dateRange.from || !dateRange.to || !gage?.locationId || !isDataFetched) {
+      return;
     }
-  }, [dateRange.from, dateRange.to]);
+
+    // @ts-ignore
+    const fromDayjs = localDayJs.tz(dateRange.from).startOf("day");
+    // @ts-ignore
+    const toDayjs = localDayJs.tz(dateRange.to).endOf("day");
+
+    chartRange.changeDates(fromDayjs, toDayjs);
+
+    setRange({
+      chartStartDate: chartRange.chartStartDate,
+      chartEndDate: chartRange.chartEndDate,
+    });
+
+    refreshData(chartRange.chartStartDate.utc().format(), chartRange.chartEndDate.utc().format());
+  }, [dateRange.from, dateRange.to, gage?.locationId, isDataFetched]);
 
   const refetchData = () => {
     refreshData();

--- a/src/components/GageDetailsChart.tsx
+++ b/src/components/GageDetailsChart.tsx
@@ -32,6 +32,7 @@ import DateRangePicker from "@common-ui/components/DateRangePicker";
 import { Dayjs } from "dayjs";
 import { normalizeSearchParams } from "@utils/navigation";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
+import { useDatePicker } from "@common-ui/contexts/DatePickerContext";
 import { GageDetailsChartNative } from "./GageDetailsChartNative";
 import type { GageDetailsChartOptions } from "./GageDetailsChartNative";
 
@@ -127,6 +128,7 @@ const HistoricEvents = observer(function HistoricEvents({
   const router = useRouter();
   const { t } = useLocale();
   const { historicEventId } = useLocalSearchParams();
+  const { hidePicker } = useDatePicker();
   const bottomSheetModalRef = useRef<BottomSheetModal>(null);
 
   const [selectedEvent, setSelectedEvent] = useState<string | undefined>();
@@ -144,6 +146,7 @@ const HistoricEvents = observer(function HistoricEvents({
         from: undefined,
         to: undefined,
       });
+      hidePicker();
       return;
     }
 
@@ -160,6 +163,7 @@ const HistoricEvents = observer(function HistoricEvents({
       to: localDayJs.tz(event.toDate).format("YYYY-MM-DD"),
     });
 
+    hidePicker();
     bottomSheetModalRef.current?.dismiss();
   };
 
@@ -312,6 +316,7 @@ export const GageDetailsChart = observer(function GageDetailsChart(props: GageDe
   const { t } = useLocale();
   const { from, to } = useLocalSearchParams();
   const { gagesStore, isDataFetched } = useStores();
+  const { hidePicker } = useDatePicker();
 
   const { isMobile } = useResponsive();
 
@@ -404,6 +409,7 @@ export const GageDetailsChart = observer(function GageDetailsChart(props: GageDe
   };
 
   const onRangeChange = (key: string) => {
+    hidePicker();
     chartRange.changeDays(parseInt(key));
 
     setRange({

--- a/src/components/__tests__/GageDetailsChart.historical.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.historical.test.tsx
@@ -1,0 +1,213 @@
+// src/components/__tests__/GageDetailsChart.historical.test.tsx
+import React from "react";
+import { render, act } from "@testing-library/react-native";
+import { GageDetailsChart } from "../GageDetailsChart";
+
+// --- Mutable mock state ---
+let mockIsDataFetched = false;
+const mockFetchDataForGage = jest.fn();
+
+// --- Store mock ---
+jest.mock("@models/helpers/useStores", () => ({
+  useStores: () => ({
+    isDataFetched: mockIsDataFetched,
+    gagesStore: {
+      fetchDataForGage: mockFetchDataForGage,
+      isFetching: false,
+    },
+  }),
+}));
+
+// --- Expo Router mock: simulate page load with historical URL params ---
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({
+    from: "2020-02-04",
+    to: "2020-02-13",
+    historicEventId: "22",
+  }),
+  useRouter: () => ({ setParams: jest.fn() }),
+}));
+
+// --- UI/infrastructure mocks ---
+jest.mock("@services/highcharts/LocalHighchartsReact", () => () => null);
+
+jest.mock("../GageDetailsChartNative", () => ({
+  GageDetailsChartNative: () => null,
+}));
+
+jest.mock("@utils/useGageChartOptions", () => ({
+  __esModule: true,
+  default: () => [{}, null],
+}));
+
+jest.mock("@utils/useTimeout", () => ({
+  useTimeout: jest.fn(),
+  useInterval: jest.fn(),
+}));
+
+jest.mock("@common-ui/contexts/LocaleContext", () => ({
+  useLocale: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock("@common-ui/utils/responsive", () => ({
+  useResponsive: () => ({ isMobile: false }),
+  isAndroid: false,
+  isIOS: false,
+  isMobile: false,
+  MobileScreen: () => null,
+  WideScreen: () => null,
+}));
+
+jest.mock("@gorhom/bottom-sheet", () => ({
+  BottomSheetModal: () => null,
+  BottomSheetView: ({ children }: any) => children,
+}));
+
+jest.mock("@react-native-picker/picker", () => ({
+  Picker: () => null,
+}));
+
+jest.mock("@common-ui/components/DateRangePicker", () => () => null);
+
+jest.mock("@common-ui/components/SegmentControl", () => ({
+  SegmentControl: () => null,
+}));
+
+jest.mock("@common-ui/components/Icon", () => () => null);
+
+jest.mock("@common-ui/components/Card", () => {
+  const React = require("react");
+  const Pass = ({ children }: any) => React.createElement(React.Fragment, null, children ?? null);
+  return { Card: Pass, CardHeader: Pass, CardFooter: Pass };
+});
+
+jest.mock("@common-ui/components/Common", () => {
+  const React = require("react");
+  const Pass = ({ children }: any) => React.createElement(React.Fragment, null, children ?? null);
+  return { Row: Pass, Cell: Pass, RowOrCell: Pass };
+});
+
+jest.mock("@common-ui/components/Conditional", () => {
+  const React = require("react");
+  return {
+    If: ({ condition, children }: any) =>
+      condition ? React.createElement(React.Fragment, null, children) : null,
+    Ternary: ({ condition, children }: any) => {
+      const arr = React.Children.toArray(children);
+      return condition ? arr[0] ?? null : arr[1] ?? null;
+    },
+  };
+});
+
+jest.mock("@common-ui/components/Button", () => ({
+  IconButton: () => null,
+  SolidButton: () => null,
+}));
+
+jest.mock("@common-ui/components/Text", () => ({
+  MediumText: () => null,
+  RegularText: () => null,
+  SmallerText: () => null,
+  LabelText: () => null,
+}));
+
+jest.mock("@utils/navigation", () => ({
+  normalizeSearchParams: (v: string | string[]) => (Array.isArray(v) ? v.join(", ") : v),
+}));
+
+jest.mock("@utils/useTimeFormat", () => ({
+  formatReadingTime: (ts: string) => ts,
+}));
+
+jest.mock("@config/config", () => ({
+  default: {
+    LIVE_CHART_DATA_REFRESH_INTERVAL: 60000,
+    GAGES_WITHOUT_DISHCARGE: [],
+  },
+}));
+
+// --- Minimal mock gage ---
+const mockGage: any = {
+  locationId: "USGS-NF10",
+  locationInfo: {
+    floodEvents: [],
+    hasDischarge: false,
+    locationName: "North Fork Snoqualmie River",
+    dischargeMin: 0,
+    dischargeMax: 0,
+    yMin: 0,
+    yMax: 20,
+  },
+  readings: [],
+  actualReadings: [],
+  predictions: [],
+  predictedFeetPerHour: 0,
+  predictedCfsPerHour: 0,
+  dataPoints: [],
+  actualPoints: [],
+  predictedPoints: [],
+  noaaForecastData: [],
+  hasData: false,
+};
+
+describe("GageDetailsChart — historical data fetch on page load", () => {
+  beforeEach(() => {
+    mockIsDataFetched = false;
+    mockFetchDataForGage.mockClear();
+  });
+
+  it("does not fetch historical data when isDataFetched is false, even with a valid gage prop", () => {
+    // Gage is available but main data hasn't loaded yet
+    render(<GageDetailsChart gage={mockGage} />);
+
+    // Broken code calls fetchDataForGage immediately on mount (no isDataFetched guard).
+    // Fixed code returns early from the guard.
+    expect(mockFetchDataForGage).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch with the correct locationId when gage is undefined on mount (real page-refresh start state)", () => {
+    // Real page-refresh: store is empty, gage is not yet available
+    render(<GageDetailsChart gage={undefined as any} />);
+
+    // The broken code calls fetchDataForGage(undefined, ...) — a silent no-op in the real
+    // store but still a call. Verify the correct locationId was never used.
+    expect(mockFetchDataForGage).not.toHaveBeenCalledWith(
+      "USGS-NF10",
+      expect.any(String),
+      expect.any(String),
+      expect.any(Boolean),
+      expect.any(Boolean)
+    );
+  });
+
+  it("fetches historical data with correct args once gage and isDataFetched become available (the bug scenario)", () => {
+    mockIsDataFetched = false;
+
+    // Start with gage=undefined: real page-refresh, store is initially empty.
+    // Broken code fires the effect immediately but with gage.locationId=undefined (no-op in real store).
+    const { rerender } = render(<GageDetailsChart gage={undefined as any} />);
+
+    // Clear any spurious calls made with undefined locationId before the store is ready.
+    mockFetchDataForGage.mockClear();
+
+    // Simulate fetchMainData() completing: gage becomes available + isDataFetched → true.
+    mockIsDataFetched = true;
+    act(() => {
+      rerender(<GageDetailsChart gage={mockGage} />);
+    });
+
+    // Broken code: effect deps are [dateRange.from, dateRange.to] — those haven't changed
+    //   → effect does NOT re-fire → fetchDataForGage is never called with a real locationId
+    //   → this assertion FAILS ✗
+    // Fixed code: new deps [gage?.locationId, isDataFetched] both changed
+    //   → effect re-fires → fetchDataForGage called with correct historical args
+    //   → this assertion PASSES ✓
+    expect(mockFetchDataForGage).toHaveBeenCalledWith(
+      "USGS-NF10",
+      expect.stringContaining("2020-02-04"),
+      expect.any(String),
+      false, // includePredictions: false for historical data
+      false // includeLastReading: false for historical data (replace, don't append)
+    );
+  });
+});

--- a/src/components/__tests__/GageDetailsChart.picker-dismiss.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.picker-dismiss.test.tsx
@@ -1,0 +1,175 @@
+// src/components/__tests__/GageDetailsChart.picker-dismiss.test.tsx
+import React from "react";
+import { render, act, fireEvent } from "@testing-library/react-native";
+import { GageDetailsChart } from "../GageDetailsChart";
+
+const mockHidePicker = jest.fn();
+
+// --- DatePickerContext mock ---
+jest.mock("@common-ui/contexts/DatePickerContext", () => ({
+  useDatePicker: () => ({
+    isVisible: false,
+    showPicker: jest.fn(),
+    hidePicker: mockHidePicker,
+  }),
+}));
+
+// --- Store mock ---
+jest.mock("@models/helpers/useStores", () => ({
+  useStores: () => ({
+    isDataFetched: true,
+    gagesStore: {
+      fetchDataForGage: jest.fn(),
+      isFetching: false,
+    },
+  }),
+}));
+
+// --- Expo Router mock ---
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({ from: undefined, to: undefined, historicEventId: undefined }),
+  useRouter: () => ({ setParams: jest.fn() }),
+}));
+
+// --- UI mocks ---
+jest.mock("@services/highcharts/LocalHighchartsReact", () => () => null);
+jest.mock("../GageDetailsChartNative", () => ({ GageDetailsChartNative: () => null }));
+jest.mock("@utils/useGageChartOptions", () => ({ __esModule: true, default: () => [{}, null] }));
+jest.mock("@utils/useTimeout", () => ({ useTimeout: jest.fn(), useInterval: jest.fn() }));
+jest.mock("@common-ui/contexts/LocaleContext", () => ({
+  useLocale: () => ({ t: (k: string) => k }),
+}));
+jest.mock("@common-ui/utils/responsive", () => ({
+  useResponsive: () => ({ isMobile: false }),
+  isAndroid: false,
+  isIOS: false,
+  isMobile: false,
+  MobileScreen: () => null,
+  WideScreen: () => null,
+}));
+jest.mock("@gorhom/bottom-sheet", () => ({
+  BottomSheetModal: () => null,
+  BottomSheetView: ({ children }: any) => children,
+}));
+jest.mock("@common-ui/components/DateRangePicker", () => () => null);
+jest.mock("@common-ui/components/Icon", () => () => null);
+jest.mock("@common-ui/components/Card", () => {
+  const React = require("react");
+  const Pass = ({ children }: any) => React.createElement(React.Fragment, null, children ?? null);
+  return { Card: Pass, CardHeader: Pass, CardFooter: Pass };
+});
+jest.mock("@common-ui/components/Common", () => {
+  const React = require("react");
+  const Pass = ({ children }: any) => React.createElement(React.Fragment, null, children ?? null);
+  return { Row: Pass, Cell: Pass, RowOrCell: Pass };
+});
+jest.mock("@common-ui/components/Conditional", () => {
+  const React = require("react");
+  return {
+    If: ({ condition, children }: any) =>
+      condition ? React.createElement(React.Fragment, null, children) : null,
+    Ternary: ({ condition, children }: any) => {
+      const arr = React.Children.toArray(children);
+      return condition ? arr[0] ?? null : arr[1] ?? null;
+    },
+  };
+});
+jest.mock("@common-ui/components/Button", () => ({
+  IconButton: () => null,
+  SolidButton: () => null,
+}));
+jest.mock("@common-ui/components/Text", () => ({
+  MediumText: () => null,
+  RegularText: () => null,
+  SmallerText: () => null,
+  LabelText: () => null,
+}));
+jest.mock("@utils/navigation", () => ({
+  normalizeSearchParams: (v: string | string[]) => (Array.isArray(v) ? v.join(", ") : v),
+}));
+jest.mock("@utils/useTimeFormat", () => ({ formatReadingTime: (ts: string) => ts }));
+jest.mock("@config/config", () => ({
+  default: { LIVE_CHART_DATA_REFRESH_INTERVAL: 60000, GAGES_WITHOUT_DISHCARGE: [] },
+}));
+
+// SegmentControl mock: renders a Pressable for each segment so tests can press them
+jest.mock("@common-ui/components/SegmentControl", () => ({
+  SegmentControl: ({ onChange, segments }: any) => {
+    const React = require("react");
+    const { Pressable } = require("react-native");
+    return (segments ?? []).map((s: any) =>
+      React.createElement(Pressable, {
+        key: s.key,
+        testID: `segment-option-${s.key}`,
+        onPress: () => onChange?.(s.key),
+      })
+    );
+  },
+}));
+
+// Picker mock: renders a Pressable that fires onValueChange with a specific event id
+jest.mock("@react-native-picker/picker", () => {
+  const React = require("react");
+  const { Pressable } = require("react-native");
+  const PickerMock = ({ onValueChange }: any) =>
+    React.createElement(Pressable, {
+      testID: "historical-event-picker",
+      onPress: () => onValueChange?.("22"),
+    });
+  PickerMock.Item = function PickerItem() {
+    return null;
+  };
+  return { Picker: PickerMock };
+});
+
+const mockGage: any = {
+  locationId: "USGS-NF10",
+  locationInfo: {
+    floodEvents: [
+      { id: 22, eventName: "February 2020 Flood", fromDate: "2020-02-04", toDate: "2020-02-13" },
+    ],
+    hasDischarge: false,
+    locationName: "North Fork Snoqualmie River",
+    dischargeMin: 0,
+    dischargeMax: 0,
+    yMin: 0,
+    yMax: 20,
+  },
+  readings: [],
+  actualReadings: [],
+  predictions: [],
+  predictedFeetPerHour: 0,
+  predictedCfsPerHour: 0,
+  dataPoints: [],
+  actualPoints: [],
+  predictedPoints: [],
+  noaaForecastData: [],
+  hasData: false,
+};
+
+describe("GageDetailsChart — picker dismissal", () => {
+  beforeEach(() => {
+    mockHidePicker.mockClear();
+  });
+
+  it("calls hidePicker when a range segment option is selected", () => {
+    const { getByTestId } = render(<GageDetailsChart gage={mockGage} />);
+
+    // RANGES keys are "14", "7", "2", "1" — press the "14" day segment
+    act(() => {
+      fireEvent.press(getByTestId("segment-option-14"));
+    });
+
+    expect(mockHidePicker).toHaveBeenCalled();
+  });
+
+  it("calls hidePicker when a historical flood event is selected", () => {
+    const { getByTestId } = render(<GageDetailsChart gage={mockGage} />);
+
+    act(() => {
+      fireEvent.press(getByTestId("historical-event-picker"));
+    });
+
+    expect(mockHidePicker).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a set of bugs in the gage detail screen's date range picker and chart interaction.

- **DateRangePicker doesn't update when a historical event is selected.** The picker stored `startDate`/`endDate` props in refs that only initialized at mount, so selecting a historical flood event from the dropdown updated the chart and URL but left the picker showing stale dates. Fixed by converting to `useState` with sync effects keyed on the timestamp's `valueOf()`, so the picker always reflects the current props. Covered by new unit tests.

- **Unnecessary chart data fetch on historical event load.** On mount, `GageDetailsChart` unconditionally fetched data for the current date range — even when the component was already entering historical mode via URL params. This caused a redundant fetch that raced against the historical data load. Fixed by skipping the mount fetch when `chartRange.isNow` is false.

- **Historical chart goes blank on page reload.** When the page was loaded (or refreshed) with historical date params in the URL (`?from=...&to=...`), the chart rendered blank. The `useEffect` that fetches historical data fired on mount before the gage store had loaded, silently did nothing (because `gage` was `undefined`), and then never re-fired — because its dependency array `[dateRange.from, dateRange.to]` didn't change when the gage became available. Fixed by adding `gage?.locationId` and `isDataFetched` to the guard condition and dependency array, so the effect re-fires once the store is ready. Covered by new unit tests.

- **Date picker popover fails to close on navigation or range/event change.** The floating date picker card (web only) stayed open when the user navigated to a different page, selected a historical flood event, or changed the day-range segment. Fixed in two parts: (1) `DatePickerProvider` now calls `hidePicker()` via a `useEffect` on `usePathname()`, so any route change auto-dismisses the picker; (2) `GageDetailsChart` explicitly calls `hidePicker()` at the start of `onRangeChange` and inside `onHistoricEventSelected` for both the clear and the select paths. `showPicker`/`hidePicker` were also wrapped in `useCallback` for stable refs. Covered by new unit tests for both the provider and the chart component.

- **Date picker requires two clicks to reopen after external dismissal.** After being hidden by navigation or a range/event change (above), the first click on the calendar icon had no effect — a second click was required. Root cause: `DatePickerComponent` maintained its own `isOpen` local state that was only reset by its internal `close()` method. External `hidePicker()` calls updated the context but left `isOpen` stale as `true`, so the next click was consumed toggling off an already-hidden picker. Fixed by adding a `useEffect` in `DatePickerComponent` that resets `isOpen` to `false` whenever `datePickerContext.isVisible` becomes `false`, regardless of whether that transition came from internal or external code.

- **Date picker popover invisible on mobile web.** On mobile-width web browsers (viewport ≤ 767px), clicking the date range picker did nothing. Root cause: `DatePickerComponent` used `isMobile` from `useResponsive()` — a CSS media query that returns `true` for any viewport ≤ 767px — to decide whether to call `BottomSheetModal.present()` (native-only) or `datePickerContext.showPicker()` (web popover). On a mobile-width browser the media query fired but `BottomSheetModal` has no web implementation and silently no-ops. Fixed by replacing the media-query check with `Platform.OS !== "web"`, so all web traffic (any viewport width) uses the popover and iOS/Android continues to use `BottomSheetModal`. Covered by a new regression test that simulates Platform.OS = "web" with a mobile-width viewport and asserts `showPicker` is called.

- **Date picker popover horizontally off-center on mobile web.** On narrow screens the popover was offset to the right rather than centered under the trigger. Fixed by using `(width - PICKER_WIDTH) / 2` as the `left` offset when the viewport is under 768px wide, centering the 300px card regardless of where the trigger element sits. Desktop web retains its existing element-aligned positioning.
