### PR TITLE
fix: date picker not working in native mobile apps

### DIFF
--- a/src/common-ui/components/DatePicker.tsx
+++ b/src/common-ui/components/DatePicker.tsx
@@ -10,7 +10,7 @@ import { Platform, Pressable, View, ViewStyle, useWindowDimensions } from "react
 import { Colors } from "@common-ui/constants/colors";
 import { SegmentControl } from "./SegmentControl";
 import { Card } from "./Card";
-import { BottomSheetModal } from "@gorhom/bottom-sheet";
+import { BottomSheetModal, BottomSheetView } from "@gorhom/bottom-sheet";
 import { useDatePicker } from "@common-ui/contexts/DatePickerContext";
 import { measure, useAnimatedRef } from "react-native-reanimated";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
@@ -381,25 +381,18 @@ const DatePickerComponent = React.forwardRef((props: DatePickerProps, ref) => {
       <View ref={pickerRef}>
         <RegularText text={formattedDate} />
       </View>
-      <BottomSheetModal
-        index={0}
-        ref={bottomSheetModalRef}
-        snapPoints={["40%"]}
-        style={$bottomSheetStyleMobile}>
-        <Cell
-          flex
-          height={170}
-          horizontal={Spacing.small}
-          top={Spacing.medium}
-          bottom={Spacing.extraLarge}>
-          <DatePicker
-            title={title}
-            minYear={minYear}
-            maxYear={maxYear}
-            selectedDate={selectedDate}
-            onChange={handleChange}
-          />
-        </Cell>
+      <BottomSheetModal index={0} ref={bottomSheetModalRef} style={$bottomSheetStyleMobile}>
+        <BottomSheetView>
+          <Cell horizontal={Spacing.small} top={Spacing.medium} bottom={Spacing.extraLarge}>
+            <DatePicker
+              title={title}
+              minYear={minYear}
+              maxYear={maxYear}
+              selectedDate={selectedDate}
+              onChange={handleChange}
+            />
+          </Cell>
+        </BottomSheetView>
       </BottomSheetModal>
     </>
   );

--- a/src/common-ui/components/__tests__/DatePicker.native.test.tsx
+++ b/src/common-ui/components/__tests__/DatePicker.native.test.tsx
@@ -1,0 +1,166 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+// src/common-ui/components/__tests__/DatePicker.native.test.tsx
+import React from "react";
+import { render, act } from "@testing-library/react-native";
+import dayjs from "dayjs";
+import DatePickerComponent from "../DatePicker";
+
+jest.mock("react-native/Libraries/Utilities/Platform", () => ({
+  default: {
+    OS: "ios",
+    select: (obj: any) => obj.ios ?? obj.native ?? obj.default,
+    isTesting: true,
+  },
+  OS: "ios",
+  select: (obj: any) => obj.ios ?? obj.native ?? obj.default,
+  isTesting: true,
+}));
+
+jest.mock("@common-ui/utils/responsive", () => ({
+  useResponsive: () => ({ isMobile: true }),
+  isMobile: true,
+  isIOS: true,
+  isAndroid: false,
+}));
+
+jest.mock("react-native-reanimated", () => ({
+  measure: jest.fn(() => null),
+  useAnimatedRef: () => ({ current: null }),
+  default: { createAnimatedComponent: (c: any) => c },
+}));
+
+const mockPresent = jest.fn();
+const mockDismiss = jest.fn();
+let bottomSheetViewRendered = false;
+jest.mock("@gorhom/bottom-sheet", () => {
+  const ReactModule = require("react");
+  const MockBottomSheetModal = ReactModule.forwardRef(({ children }: any, ref: any) => {
+    ReactModule.useImperativeHandle(ref, () => ({
+      present: mockPresent,
+      dismiss: mockDismiss,
+    }));
+    return ReactModule.createElement(ReactModule.Fragment, null, children);
+  });
+  MockBottomSheetModal.displayName = "MockBottomSheetModal";
+  const MockBottomSheetView = ({ children }: any) => {
+    bottomSheetViewRendered = true;
+    return ReactModule.createElement(ReactModule.Fragment, null, children);
+  };
+  return {
+    BottomSheetModal: MockBottomSheetModal,
+    BottomSheetView: MockBottomSheetView,
+  };
+});
+
+const mockShowPicker = jest.fn();
+const mockHidePicker = jest.fn();
+jest.mock("@common-ui/contexts/DatePickerContext", () => ({
+  useDatePicker: () => ({
+    isVisible: false,
+    showPicker: mockShowPicker,
+    hidePicker: mockHidePicker,
+  }),
+}));
+
+jest.mock("@common-ui/contexts/LocaleContext", () => ({
+  useLocale: () => ({ t: (k: string) => k }),
+}));
+
+jest.mock("react-native-gesture-handler", () => {
+  const RN = require("react-native");
+  return {
+    ScrollView: RN.ScrollView,
+    GestureHandlerRootView: RN.View,
+  };
+});
+
+jest.mock("@common-ui/components/Text", () => ({
+  SmallTitle: () => null,
+  RegularText: () => null,
+}));
+
+jest.mock("@common-ui/components/Common", () => {
+  const ReactModule = require("react");
+  const Pass = ({ children }: any) =>
+    ReactModule.createElement(ReactModule.Fragment, null, children ?? null);
+  return {
+    AbsoluteContainer: Pass,
+    Cell: Pass,
+    Row: Pass,
+    Separator: () => null,
+  };
+});
+
+jest.mock("@common-ui/components/Conditional", () => {
+  const ReactModule = require("react");
+  return {
+    If: ({ condition, children }: any) =>
+      condition ? ReactModule.createElement(ReactModule.Fragment, null, children) : null,
+    Ternary: ({ condition, children }: any) => {
+      const arr = ReactModule.Children.toArray(children);
+      return condition ? arr[0] ?? null : arr[1] ?? null;
+    },
+  };
+});
+
+jest.mock("@common-ui/components/SegmentControl", () => ({
+  SegmentControl: () => null,
+}));
+
+jest.mock("@common-ui/components/Card", () => {
+  const ReactModule = require("react");
+  const Pass = ({ children }: any) =>
+    ReactModule.createElement(ReactModule.Fragment, null, children ?? null);
+  return { Card: Pass };
+});
+
+jest.mock("@services/localDayJs", () => {
+  const dayjsModule = require("dayjs");
+  return Object.assign(dayjsModule, { tz: dayjsModule });
+});
+
+const selectedDate = dayjs("2026-04-01");
+
+describe("DatePickerComponent on native iOS", () => {
+  beforeEach(() => {
+    mockShowPicker.mockClear();
+    mockHidePicker.mockClear();
+    mockPresent.mockClear();
+    mockDismiss.mockClear();
+    bottomSheetViewRendered = false;
+  });
+
+  it("renders BottomSheetView as a child of BottomSheetModal", () => {
+    const ref = React.createRef<any>();
+    render(<DatePickerComponent ref={ref} selectedDate={selectedDate} onChange={jest.fn()} />);
+
+    expect(bottomSheetViewRendered).toBe(true);
+  });
+
+  it("calls BottomSheetModal.present() when opened — not the popover showPicker()", () => {
+    const ref = React.createRef<any>();
+    render(<DatePickerComponent ref={ref} selectedDate={selectedDate} onChange={jest.fn()} />);
+
+    act(() => {
+      ref.current?.open();
+    });
+
+    expect(mockPresent).toHaveBeenCalledTimes(1);
+    expect(mockShowPicker).not.toHaveBeenCalled();
+  });
+
+  it("calls BottomSheetModal.dismiss() when closed — not the popover hidePicker()", () => {
+    const ref = React.createRef<any>();
+    render(<DatePickerComponent ref={ref} selectedDate={selectedDate} onChange={jest.fn()} />);
+
+    act(() => {
+      ref.current?.open();
+    });
+    act(() => {
+      ref.current?.close();
+    });
+
+    expect(mockDismiss).toHaveBeenCalledTimes(1);
+    expect(mockHidePicker).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Fix native mobile date picker

### Summary
On native iOS and Android, tapping the date range picker on the gauge details page either did nothing or showed an empty/collapsed bottom sheet — making the chart's date range unselectable on mobile. Web (mobile viewport and desktop) was working correctly after `d388ca4`, but the native flow was broken.

This PR fixes the native bottom-sheet rendering so the start and end date pickers both open with a fully visible year/month/day calendar, and the start→end auto-advance flow works end-to-end.

### Root cause
`@gorhom/bottom-sheet` v5 requires the immediate child of `<BottomSheetModal>` to be `<BottomSheetView>` (or one of its scrollable variants). Without that wrapper, two things break:
1. The modal can't measure content height, so on native it collapses to zero with `enableDynamicSizing=true` (the v5 default).
2. Gestures inside the modal don't get the right scrollable context.

A secondary layout issue surfaced once the wrapper was added: the inner `<Cell flex height={170} ...>` constrained the Days/Months `flex` row chain into a 170px box even though the modal was much taller, so Months and Days rendered as invisible slivers (Years rendered correctly only because its `<ScrollView style={{ height: 170 }}>` ignored the parent constraint).

### Changes

**`src/common-ui/components/DatePicker.tsx`**
- Added `BottomSheetView` import from `@gorhom/bottom-sheet`.
- Wrapped the modal's children in `<BottomSheetView>`.
- Dropped `flex` and `height={170}` from the inner wrapper Cell so the Days/Months row chain has real space to lay out.
- Dropped `snapPoints={["40%"]}` and let gorhom v5's default dynamic sizing measure `BottomSheetView`'s intrinsic content height.

**`src/common-ui/components/__tests__/DatePicker.native.test.tsx`** (new)
- Native-iOS test suite with `Platform.OS = "ios"` mocked at the top level (kept in its own file so `jest.resetModules()` semantics don't conflict with `@testing-library/react-native`'s `afterAll` registration).
- Asserts `<BottomSheetView>` renders inside the modal, `present()` fires on open, and `dismiss()` fires on close — closing the test gap that let this regression slip through (the existing `DatePicker.test.tsx` only exercised the `Platform.OS = "web"` branch).

### Verification
- ✅ iOS simulator: full flow works — tap date range → start picker opens with calendar visible → year/month/day all render → start dismisses → end picker auto-opens → both dates reflected on chart.
- ✅ Android emulator: same flow works.
- ✅ Web (mobile viewport): in-app overlay flow from `cc65696` + `d388ca4` still works.
- ✅ Web (desktop viewport): popover still anchors to the picker text.
- ✅ `npm test` — 56 passed (including 3 new native iOS tests).
- ✅ `npm run lint` — 0 errors.
- ✅ `npx tsc --noEmit` — clean.

### Investigated and ruled out
- The plan anticipated a sequential start→end modal-presentation race (gorhom dropping a `present()` call when fired immediately after a `dismiss()` animation). Logs from a debug-instrumentation pass on iOS showed the start→end transition firing cleanly back-to-back, so no `requestAnimationFrame` deferral was needed. The `DateRangePicker.tsx` source is unchanged in this PR. If the race surfaces on a different device or under heavier load, the fix is documented in the plan for follow-up.

### Plan
Full plan with as-built notes: [docs/superpowers/plans/2026-05-01-fix-native-date-picker.md](docs/superpowers/plans/2026-05-01-fix-native-date-picker.md)
