### PR TITLE
fix: native app slowness

### DIFF
--- a/src/components/ForecastChart.tsx
+++ b/src/components/ForecastChart.tsx
@@ -16,8 +16,6 @@ import { Cell } from "@common-ui/components/Common";
 import { SegmentControl } from "@common-ui/components/SegmentControl";
 import { useStores } from "@models/helpers/useStores";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import { ForecastChartNative } from "./ForecastChartNative";
-import type { ForecastChartOptions } from "./ForecastChartNative";
 
 export const CHART_HEIGHT = 400;
 
@@ -68,7 +66,7 @@ const Charts = (props: ChartsProps) => {
 
   return (
     <Ternary condition={isMobile}>
-      <ForecastChartNative options={options as unknown as ForecastChartOptions} />
+      <HighchartsReactNative options={options} styles={{ height: CHART_HEIGHT }} />
       <LocalHighchartsReact options={options} />
     </Ternary>
   );

--- a/src/components/GageDetailsChart.tsx
+++ b/src/components/GageDetailsChart.tsx
@@ -4,6 +4,7 @@ import { observer } from "mobx-react-lite";
 import { useLocalSearchParams, useRouter } from "expo-router";
 
 import LocalHighchartsReact from "@services/highcharts/LocalHighchartsReact";
+import HighchartsReactNative from "@services/highcharts/HighchartsReactNative";
 
 import { Gage, GageChartDataType } from "@models/Gage";
 import { If, Ternary } from "@common-ui/components/Conditional";
@@ -32,8 +33,6 @@ import DateRangePicker from "@common-ui/components/DateRangePicker";
 import { Dayjs } from "dayjs";
 import { normalizeSearchParams } from "@utils/navigation";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import { GageDetailsChartNative } from "./GageDetailsChartNative";
-import type { GageDetailsChartOptions } from "./GageDetailsChartNative";
 
 interface GageDetailsChartProps {
   gage: Gage;
@@ -78,18 +77,16 @@ const CHART_DATA_TYPES = (t) => [
 
 const SELECT_EVENT = "gageDetailsChart._selectEvent";
 
-const Charts = (props: ChartsProps) => {
-  const { options } = props;
-
+const Charts = React.memo(function Charts({ options }: ChartsProps) {
   return (
     <Cell height={320}>
       <Ternary condition={isMobile}>
-        <GageDetailsChartNative options={options as unknown as GageDetailsChartOptions} />
+        <HighchartsReactNative options={options} styles={{ height: 320 }} />
         <LocalHighchartsReact options={options} />
       </Ternary>
     </Cell>
   );
-};
+});
 
 const PickerSelector = ({
   floodEvents = [],

--- a/src/services/highcharts/HighchartsLayout.tsx
+++ b/src/services/highcharts/HighchartsLayout.tsx
@@ -1,78 +1,72 @@
-export const LAYOUT_HTML = `
-<!-- Copied from https://github.com/highcharts/highcharts-react-native/blob/master/dist/highcharts-layout/index.html -->
-
+const BASE_HTML = `
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1.00001, viewport-fit=cover" />
-		<style>
-			#container {
-				width:100%;
-				height:100%;
-				top:0;
-				left:0;
-				right:0;
-				bottom:0;
-				position:absolute;
-				user-select: none;
-				-webkit-user-select: none;
-			}
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    {{MODULE_SCRIPTS}}
+    <style>
+      body { margin: 0; padding: 0; overflow: hidden; }
+      #container {
+        width: 100%;
+        height: 100%;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        position: absolute;
+        user-select: none;
+        -webkit-user-select: none;
+      }
+      * {
+        -webkit-touch-callout: none;
+        -webkit-user-select: none;
+        -khtml-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+      }
+    </style>
+    <script>
+      const hcUtils = {
+        parseOptions: function (chartOptions) {
+          const parseFunction = this.parseFunction;
+          return JSON.parse(chartOptions, function (val, key) {
+            if (typeof key === 'string' && key.indexOf('function') > -1) {
+              return parseFunction(key);
+            }
+            return key;
+          });
+        },
+        parseFunction: function (fc) {
+          const fcArgs = fc.match(/\\((.*?)\\)/)[1];
+          const fcbody = fc.split('{');
+          return new Function(fcArgs, '{' + fcbody.slice(1).join('{'));
+        }
+      };
 
-			* {
-				-webkit-touch-callout: none;
-				-webkit-user-select: none; /* Disable selection/copy in UIWebView */
-				-khtml-user-select: none;
-				-moz-user-select: none;
-				-ms-user-select: none;
-				user-select: none;
-			}
-		</style>
-		<script>
-			const hcUtils = {
-					// convert string to JSON, including functions.
-					parseOptions: function (chartOptions) {
-						const parseFunction = this.parseFunction;
-
-						const options = JSON.parse(chartOptions, function (val, key) {
-							if (typeof key === 'string' && key.indexOf('function') > -1) {
-								return parseFunction(key);
-							} else {
-								return key;
-							}
-						});
-
-						return options;
-					},
-					// convert funtion string to function
-					parseFunction: function (fc) {
-						const fcArgs = fc.match(/\((.*?)\)/)[1],
-								fcbody = fc.split('{');
-
-						return new Function(fcArgs, '{' + fcbody.slice(1).join('{'));
-					}
-			};
-
-			// Communication between React app and webview. Receive chart options as string.
-			document.addEventListener('message', function (data) {
-				Highcharts.charts[0].update(
-				hcUtils.parseOptions(data.data),
-				true,
-				true,
-				true
-				);
-			});
-
-			window.addEventListener('message', function (data) {
-					Highcharts.charts[0].update(
-					hcUtils.parseOptions(data.data),
-					true,
-					true,
-					true
-				);
-			});
-   	</script>
+      document.addEventListener('message', function (data) {
+        if (Highcharts.charts[0]) {
+          Highcharts.charts[0].update(hcUtils.parseOptions(data.data), true, true, true);
+        }
+      });
+      window.addEventListener('message', function (data) {
+        if (Highcharts.charts[0]) {
+          Highcharts.charts[0].update(hcUtils.parseOptions(data.data), true, true, true);
+        }
+      });
+    </script>
   </head>
   <body>
-  	<div id="container">Loading...</div>
+    <div id="container"></div>
   </body>
 </html>
 `;
+
+export const buildLayoutHtml = (modules: string[] = []): string => {
+  const moduleScripts = modules
+    .map((m) => `    <script src="https://code.highcharts.com/modules/${m}.js"></script>`)
+    .join("\n");
+  return BASE_HTML.replace("{{MODULE_SCRIPTS}}", moduleScripts);
+};
+
+export const LAYOUT_HTML = buildLayoutHtml();

--- a/src/services/highcharts/HighchartsReactNative.tsx
+++ b/src/services/highcharts/HighchartsReactNative.tsx
@@ -1,115 +1,50 @@
-// Copied from https://github.com/highcharts/highcharts-react-native/blob/master/dist/src/HighchartsReactNative.js
+// Adapted from https://github.com/highcharts/highcharts-react-native
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { View, ViewStyle } from "react-native";
 import { WebView, WebViewMessageEvent, WebViewProps } from "react-native-webview";
-import { LAYOUT_HTML } from "./HighchartsLayout";
-
-const stringifiedScripts = {};
-
-let cdnPath = "code.highcharts.com/";
-let httpProto = "http://";
+import { buildLayoutHtml } from "./HighchartsLayout";
 
 interface HighchartsReactNativeProps {
-  data?: any; // Data to be stored as global variable in Webview.
-  options: Highcharts.Options; // Highcharts options.
-  modules?: string[]; // List of modules to be loaded.
-  setOptions?: Record<string, unknown>; // Highcharts setOptions.
-  styles?: ViewStyle; // Styles to be applied to the container.
-  webviewProps?: WebViewProps; // Props to be passed to the WebView.
-  onMessage?: (data: string) => void; // Callback for WebView messages.
-  startInLoadingState?: boolean; // Whether to show loading indicator on WebView.
-  webviewStyles?: ViewStyle; // Styles to be applied to the WebView.
+  options: Highcharts.Options;
+  modules?: string[];
+  styles?: ViewStyle;
+  webviewProps?: WebViewProps;
+  onMessage?: (data: string) => void;
+  startInLoadingState?: boolean;
+  webviewStyles?: ViewStyle;
+  setOptions?: Record<string, unknown>;
 }
 
-type ScriptsProps = Pick<HighchartsReactNativeProps, "data" | "modules" | "options" | "setOptions">;
+// Serialize Highcharts options to a JSON string, converting functions to
+// string representations so they survive the RN→WebView boundary.
+const serialize = (chartOptions: Highcharts.Options, isUpdate?: boolean): string => {
+  const hcFunctions: Record<string, string> = {};
+  let i = 0;
 
-const serialize = (chartOptions: Highcharts.Options, isUpdate?: boolean) => {
-  let hcFunctions = {},
-    serializedOptions,
-    i = 0;
-
-  serializedOptions = JSON.stringify(chartOptions, function (_val, key) {
-    const fcId = "###HighchartsFunction" + i + "###";
-
-    // set reference to function for the later replacement
-    if (typeof key === "function") {
-      hcFunctions[fcId] = key.toString();
+  let serialized = JSON.stringify(chartOptions, function (_key, value) {
+    if (typeof value === "function") {
+      const fcId = "###HCF" + i + "###";
+      hcFunctions[fcId] = value.toString();
       i++;
-      return isUpdate ? key.toString() : fcId;
+      return isUpdate ? value.toString() : fcId;
     }
-
-    return key;
+    return value;
   });
 
-  // replace ids with functions.
   if (!isUpdate) {
-    Object.keys(hcFunctions).forEach(function (key) {
-      serializedOptions = serializedOptions.replace('"' + key + '"', hcFunctions[key]);
+    Object.keys(hcFunctions).forEach((key) => {
+      serialized = serialized.replace('"' + key + '"', hcFunctions[key]);
     });
   }
 
-  return serializedOptions;
-};
-
-const buildScripts = (props: ScriptsProps) => {
-  const { data, modules, options, setOptions } = props;
-
-  return `(function() {
-        window.data = \"${data ? data : null}\";
-        var modulesList = ${JSON.stringify(modules)};
-        var readable = ${JSON.stringify(stringifiedScripts)}
-
-        function loadScripts(file, callback, redraw) {
-          var hcScript = document.createElement('script');
-          hcScript.innerHTML = readable[file]
-          document.body.appendChild(hcScript);
-
-          if (callback) {
-            callback.call();
-          }
-
-          if (redraw) {
-            Highcharts.setOptions(${serialize(setOptions)});
-            Highcharts.chart("container", ${serialize(options)});
-          }
-        }
-
-        loadScripts('highcharts', function () {
-          var redraw = modulesList.length > 0 ? false : true;
-          loadScripts('highcharts-more', function () {
-              if (modulesList.length > 0) {
-                  for (var i = 0; i < modulesList.length; i++) {
-                      if (i === (modulesList.length - 1)) {
-                          redraw = true;
-                      } else {
-                          redraw = false;
-                      }
-                      loadScripts(modulesList[i], undefined, redraw, true);
-                  }
-              }
-          }, redraw);
-        }, false);
-
-        return true;
-      })();
-    `;
-};
-
-const addScript = async (name: string, isModule: boolean) => {
-  const moduleUrl = httpProto + cdnPath + (isModule ? "modules/" : "") + name + ".js";
-
-  const response = await fetch(moduleUrl).catch((error) => {
-    throw error;
-  });
-  stringifiedScripts[name] = await response.text();
+  return serialized;
 };
 
 const HighchartsReactNative = React.memo((props: HighchartsReactNativeProps) => {
   const {
     styles,
     onMessage,
-    data,
     startInLoadingState = true,
     webviewStyles,
     webviewProps = {},
@@ -119,53 +54,50 @@ const HighchartsReactNative = React.memo((props: HighchartsReactNativeProps) => 
   } = props;
 
   const webviewRef = useRef<WebView>(null);
+  const [chartReady, setChartReady] = useState(false);
 
-  const [modulesReady, setModulesReady] = useState(false);
+  // Build HTML once per modules list — changes to modules force a WebView reload.
+  const html = useMemo(() => buildLayoutHtml(modules), [modules.join(",")]);
 
-  const handleMessage = (event: WebViewMessageEvent) => {
-    onMessage && onMessage(event.nativeEvent.data);
-  };
-
+  // Send updated options to the already-rendered chart via postMessage.
   useEffect(() => {
-    if (!modulesReady) {
+    if (!chartReady) {
       return;
     }
-
     webviewRef.current?.postMessage(serialize(options, true));
-  }, [options, modulesReady]);
+  }, [options, chartReady]);
 
-  useEffect(() => {
-    const getModules = async () => {
-      await addScript("highcharts", false);
+  const handleMessage = (event: WebViewMessageEvent) => {
+    const { data } = event.nativeEvent;
+    if (data === "chart-ready") {
+      setChartReady(true);
+      return;
+    }
+    onMessage?.(data);
+  };
 
-      if (modules.length > 0) {
-        await addScript("highcharts-more", false);
-
-        for (let i = 0; i < modules.length; i++) {
-          await addScript(modules[i], true);
-        }
+  // Highcharts is loaded by the HTML via <script src>. This script only
+  // initializes the chart — it is small enough to inject safely.
+  const initScript = `
+    (function() {
+      try {
+        Highcharts.setOptions(${serialize(setOptions)});
+        Highcharts.chart('container', ${serialize(options)});
+        window.ReactNativeWebView.postMessage('chart-ready');
+      } catch (e) {
+        window.ReactNativeWebView.postMessage('error:' + e.message);
       }
-
-      setModulesReady(true);
-    };
-
-    getModules();
-  }, []);
-
-  // Do not render anything until modules are ready.
-  if (!modulesReady) {
-    return null;
-  }
-
-  const runFirst = buildScripts({ data, modules, options, setOptions });
+      return true;
+    })();
+  `;
 
   return (
     <View style={styles}>
       <WebView
         ref={webviewRef}
         onMessage={handleMessage}
-        source={{ html: LAYOUT_HTML }}
-        injectedJavaScript={runFirst}
+        source={{ html, baseUrl: "https://code.highcharts.com/" }}
+        injectedJavaScript={initScript}
         originWhitelist={["*"]}
         automaticallyAdjustContentInsets={true}
         allowFileAccess={true}


### PR DESCRIPTION
## Fix severe native mobile performance issues (30s freezes, slow navigation)

### Root cause

`victory-native@36.6.11` (SVG-based) is incompatible with React Native's new architecture
(`newArchEnabled: true`, Fabric/JSI in RN 0.83). Under Fabric, each native SVG node is created
synchronously on the JS thread via JSI — so rendering a gage chart with 200–400 data points
blocked the JS thread for 30+ seconds. This affected all navigation and UI interactions, not
just charts, because the JS thread drives gesture recognition and animation.

### Fix

Replace Victory Native with the existing `HighchartsReactNative` WebView component for both the
gage details chart and the forecast chart. Highcharts runs inside a separate WebView process,
completely off the main JS thread. The web version already used Highcharts directly and was
unaffected.

The existing `HighchartsReactNative` implementation had two bugs that prevented it from working:

1. It fetched the ~80KB Highcharts library via RN's `fetch` and embedded it in
   `injectedJavaScript` — this silently fails above RN WebView's injection size limit, leaving
   the chart blank
2. It used `http://` for the CDN fetch, which iOS App Transport Security blocks

Both are fixed by loading Highcharts from CDN directly in the WebView HTML via
`<script src="https://...">`. The `injectedJavaScript` now only sends the small chart
initialization call.

### Secondary fixe

- **`GageDetailsChart.tsx`**: Wrapped `Charts` in `React.memo` to prevent chart re-renders on
  every `isFetching` toggle. Used a functional updater for `setRange` so that a date range
  effect that produces unchanged dates doesn't trigger a full chart options recompute.

### Files left in place but now unused

`GageDetailsChartNative.tsx` and `ForecastChartNative.tsx` (the Victory Native implementations)
are no longer referenced and can be deleted in a follow-up once the fix is confirmed stable.

### Backlog

**No tooltip on native chart tap.** On web, tapping a data point shows a Highcharts tooltip
with the reading value. On native (WebView-based Highcharts), this interaction does not
currently work — taps are not forwarded from the React Native touch system into the WebView.
Highcharts' built-in touch tooltip support should work once the WebView touch configuration is
tuned; tracked for a follow-up PR.
