### PR TITLE
protect against loading map before region is loaded

### DIFF
--- a/src/components/MapLibreWebGageMap.tsx
+++ b/src/components/MapLibreWebGageMap.tsx
@@ -42,6 +42,9 @@ const MapLibreWebGageWebMap = ({
   singleGage,
 }: InternalGageMapProps) => {
   const mapStyleUrl = useMemo(() => {
+    if (!region) {
+      return "";
+    }
     let url = mapStyleBaseUrl;
     if (!url.endsWith("/")) {
       url += "/";


### PR DESCRIPTION
same fix as was made in mobile chart -- the map control can be loaded before the region is downloaded.

repro is to load the site in a new incognito window.