### PR TITLE
fix: use useLocalSearchParams in GageScreen to prevent stale fetches

### DIFF
--- a/app/(root)/gage/[id].tsx
+++ b/app/(root)/gage/[id].tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { TouchableOpacity } from "react-native";
-import { ErrorBoundaryProps, Link, Stack, useGlobalSearchParams } from "expo-router";
+import { ErrorBoundaryProps, Link, Stack, useLocalSearchParams } from "expo-router";
 import Head from "expo-router/head";
 
 import { observer } from "mobx-react-lite";
@@ -121,7 +121,7 @@ const GageDetailsScreen = observer(function GageDetailsScreen({ gage }: { gage: 
   const { gagesStore, regionStore } = useStores();
   const { t } = useLocale();
 
-  const { id } = useGlobalSearchParams();
+  const { id } = useLocalSearchParams();
 
   const gageId = Array.isArray(id) ? id.join("/") : id;
 
@@ -243,7 +243,7 @@ const GageDetailsScreen = observer(function GageDetailsScreen({ gage }: { gage: 
 });
 
 const GageScreen = observer(function GageScreen() {
-  const { id } = useGlobalSearchParams();
+  const { id } = useLocalSearchParams();
   const { gagesStore } = useStores();
   const { t } = useLocale();
 


### PR DESCRIPTION
This fixes the bug that i was seeing where navigating between pages incrementally increased the number of initial data requests. 

Here's the bug description I fed to Claude:
Repro: 
1. in web browser enable dev settings
2. view network tab
3. filter for just "GetGageReadingsUTC"
4. Refresh browser on a specific gauge. 
5. See one request to GetGageReadingsUTC
6. Click "Downstream Gauge" to navigate to the next gauge
Result: See two requests to GetGageReadingsUTC for the same guage but with slightly different time stamps
Expect: one request
7. Click "Downstream Guage" again to navigate to the next gauge
Result: Now see three requests GetGageReadingsUTC
Expect: one

This trend continues. Every time you view a gauge the number of initial requests increments by one.

From Claude:
When navigating between gauges, Expo Router briefly keeps the old gauge screen mounted alongside the new one. Both instances were reading the gauge id via useGlobalSearchParams, which returns the CURRENT URL — so the old screen would receive the NEW gauge as its `gage` prop. Its child GageDetailsChart, which reads its own from/to via useLocalSearchParams, would then fire a fetch for the new gauge using the old route's stale historic bounds. Each previously-visited gauge accumulated one extra spurious fetch per navigation.

Switching GageScreen and GageDetailsScreen to useLocalSearchParams pins each mounted instance to its own route's id, so the old screen keeps rendering its own gauge (and its fetch effect doesn't re-fire) while the new screen renders the new gauge.