### PR TITLE
Feat: Live button

### DIFF
--- a/src/components/GageDetailsChart.tsx
+++ b/src/components/GageDetailsChart.tsx
@@ -29,6 +29,7 @@ import { FloodEvent } from "@models/LocationInfo";
 import { DataPoint } from "@models/Forecasts";
 import { formatReadingTime } from "@utils/useTimeFormat";
 import { BottomSheetModal, BottomSheetView } from "@gorhom/bottom-sheet";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Icon from "@common-ui/components/Icon";
 import DatePickerVariantSwitch from "./DatePickerVariantSwitch";
 import { Dayjs } from "dayjs";
@@ -137,6 +138,7 @@ const HistoricEvents = observer(function HistoricEvents({
   const { hidePicker } = useDatePicker();
   const { getTimezone } = useStores();
   const tz = getTimezone();
+  const insets = useSafeAreaInsets();
   const bottomSheetModalRef = useRef<BottomSheetModal>(null);
 
   const urlEventId = Array.isArray(historicEventId) ? historicEventId[0] : historicEventId;
@@ -209,9 +211,9 @@ const HistoricEvents = observer(function HistoricEvents({
               index={0}
               detached={true}
               ref={bottomSheetModalRef}
-              snapPoints={["40%"]}
+              snapPoints={["50%"]}
               style={$bottomSheetStyle}>
-              <BottomSheetView>
+              <BottomSheetView style={{ paddingBottom: insets.bottom + Spacing.medium }}>
                 <PickerSelector
                   historicEventId={selectedEvent ?? historicEventId}
                   floodEvents={floodEvents}

--- a/src/components/GageDetailsChart.tsx
+++ b/src/components/GageDetailsChart.tsx
@@ -1,12 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import {
-  ActivityIndicator,
-  Pressable,
-  TextStyle,
-  TouchableOpacity,
-  View,
-  ViewStyle,
-} from "react-native";
+import { ActivityIndicator, TextStyle, TouchableOpacity, View, ViewStyle } from "react-native";
 import { observer } from "mobx-react-lite";
 import { useLocalSearchParams, useRouter } from "expo-router";
 
@@ -31,14 +24,7 @@ import Config from "@config/config";
 import { IconButton, SolidButton } from "@common-ui/components/Button";
 import { Colors } from "@common-ui/constants/colors";
 import { Picker } from "@react-native-picker/picker";
-import {
-  LabelText,
-  MediumText,
-  MediumTitle,
-  RegularText,
-  SmallerText,
-  SmallTitle,
-} from "@common-ui/components/Text";
+import { LabelText, MediumText, RegularText, SmallerText } from "@common-ui/components/Text";
 import { FloodEvent } from "@models/LocationInfo";
 import { DataPoint } from "@models/Forecasts";
 import { formatReadingTime } from "@utils/useTimeFormat";
@@ -60,7 +46,7 @@ interface ChartsProps {
 }
 
 // Ranges available for selection
-const RANGES = (t) => [
+const RANGES = (t, showLive: boolean) => [
   {
     key: "14",
     title: t("forecastChart.rangeDays", { days: 14 }),
@@ -77,6 +63,14 @@ const RANGES = (t) => [
     key: "1",
     title: `1 ${t("forecastChart.rangeDay")}`,
   },
+  ...(showLive
+    ? [
+        {
+          key: "live",
+          title: t("forecastChart.live"),
+        },
+      ]
+    : []),
 ];
 
 // Possible chart data types
@@ -323,41 +317,6 @@ const CrestInfo = observer(function CrestInfo({ crest }: { crest: DataPoint }) {
   );
 });
 
-/** "Live" reset button — returns the chart to the default live window. */
-const LiveButton = observer(function LiveButton({ isNow }: { isNow: boolean }) {
-  const router = useRouter();
-  const { t } = useLocale();
-  const { isMobile } = useResponsive();
-
-  if (isNow) {
-    return null;
-  }
-
-  const TextComponent = isMobile ? SmallTitle : MediumTitle;
-
-  const handlePress = () => {
-    router.setParams({
-      historicEventId: undefined,
-      from: `-${CHART_DEFAULT_RANGE_DAYS}`,
-      to: NOW_LITERAL,
-    });
-  };
-
-  return (
-    <Pressable
-      onPress={handlePress}
-      style={(state) => [
-        $liveButton,
-        state.pressed && $liveButtonPressed,
-        state.hovered && $liveButtonHovered,
-      ]}>
-      <TextComponent color={Colors.dark} align="center">
-        {t("forecastChart.live")}
-      </TextComponent>
-    </Pressable>
-  );
-});
-
 export const GageDetailsChart = observer(function GageDetailsChart(props: GageDetailsChartProps) {
   const { gage, hideChart } = props;
 
@@ -467,6 +426,16 @@ export const GageDetailsChart = observer(function GageDetailsChart(props: GageDe
   //                today in gauge tz, flip to live mode instead.
   const onRangeChange = (key: string) => {
     hidePicker();
+
+    if (key === "live") {
+      router.setParams({
+        historicEventId: undefined,
+        from: `-${CHART_DEFAULT_RANGE_DAYS}`,
+        to: NOW_LITERAL,
+      });
+      return;
+    }
+
     const days = parseInt(key, 10);
 
     if (range.isNow) {
@@ -545,14 +514,13 @@ export const GageDetailsChart = observer(function GageDetailsChart(props: GageDe
           <Cell flex>
             <SegmentControl
               bottom={Spacing.zero}
-              segments={RANGES(t)}
+              segments={RANGES(t, !range.isNow)}
               selectedSegment={rangeOption}
               onChange={onRangeChange}
             />
           </Cell>
           <Cell flex align="flex-end">
             <If condition={!isMobile}>
-              <LiveButton isNow={range.isNow} />
               <DatePickerVariantSwitch
                 locationId={gage?.locationId}
                 startDate={range.chartStartDate}
@@ -565,22 +533,16 @@ export const GageDetailsChart = observer(function GageDetailsChart(props: GageDe
           </Cell>
         </Row>
         <If condition={isMobile}>
-          <Row align="center" top={Spacing.tiny}>
-            <Cell flex />
-            <Cell>
-              <DatePickerVariantSwitch
-                locationId={gage?.locationId}
-                startDate={range.chartStartDate}
-                endDate={range.chartEndDate}
-                timezone={tz}
-                onChange={onDateRangeChange}
-                onRangeRestricted={() => setShowRangeWarning(true)}
-              />
-            </Cell>
-            <Cell flex align="flex-start">
-              <LiveButton isNow={range.isNow} />
-            </Cell>
-          </Row>
+          <Cell align="center" top={Spacing.tiny}>
+            <DatePickerVariantSwitch
+              locationId={gage?.locationId}
+              startDate={range.chartStartDate}
+              endDate={range.chartEndDate}
+              timezone={tz}
+              onChange={onDateRangeChange}
+              onRangeRestricted={() => setShowRangeWarning(true)}
+            />
+          </Cell>
         </If>
       </CardHeader>
       {showRangeWarning && (
@@ -665,21 +627,4 @@ const $bottomSheetStyle: ViewStyle = {
     width: 0,
     height: -4,
   },
-};
-
-const $liveButton: ViewStyle = {
-  paddingHorizontal: Spacing.extraSmall,
-  paddingVertical: Spacing.extraSmall,
-  backgroundColor: "transparent",
-  borderRadius: Spacing.extraSmall,
-};
-
-const $liveButtonPressed: ViewStyle = {
-  backgroundColor: Colors.lightGrey,
-  opacity: 0.8,
-};
-
-const $liveButtonHovered: ViewStyle = {
-  backgroundColor: Colors.lightGrey,
-  opacity: 0.8,
 };

--- a/src/components/GageDetailsChart.tsx
+++ b/src/components/GageDetailsChart.tsx
@@ -114,7 +114,7 @@ const PickerSelector = ({
 
   return (
     <Picker
-      selectedValue={eventId}
+      selectedValue={eventId ?? SELECT_EVENT}
       onValueChange={onHistoricEventSelected}
       style={[$pickerStyle, width]}>
       <Picker.Item label={t(SELECT_EVENT)} value={SELECT_EVENT} />
@@ -139,7 +139,16 @@ const HistoricEvents = observer(function HistoricEvents({
   const tz = getTimezone();
   const bottomSheetModalRef = useRef<BottomSheetModal>(null);
 
-  const [selectedEvent, setSelectedEvent] = useState<string | undefined>();
+  const urlEventId = Array.isArray(historicEventId) ? historicEventId[0] : historicEventId;
+
+  const [selectedEvent, setSelectedEvent] = useState<string | undefined>(urlEventId);
+
+  // Keep the iOS bottom-sheet's pending selection in sync with the URL.
+  // Without this, clearing `historicEventId` via a range change leaves the
+  // sheet showing the previously-selected event the next time it opens.
+  useEffect(() => {
+    setSelectedEvent(urlEventId);
+  }, [urlEventId]);
 
   // Update chart when historic event selected
   const onHistoricEventSelected = (historicEventId: string) => {
@@ -179,9 +188,7 @@ const HistoricEvents = observer(function HistoricEvents({
     bottomSheetModalRef.current?.present();
   };
 
-  const historicEventIdNum = Array.isArray(historicEventId)
-    ? parseInt(historicEventId[0])
-    : parseInt(historicEventId);
+  const historicEventIdNum = parseInt(urlEventId);
   const title =
     floodEvents.find((e) => e.id === historicEventIdNum)?.eventName ??
     t("gageDetailsChart.selectEvent");

--- a/src/components/GageDetailsChart.tsx
+++ b/src/components/GageDetailsChart.tsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { ActivityIndicator, TextStyle, TouchableOpacity, View, ViewStyle } from "react-native";
+import {
+  ActivityIndicator,
+  Pressable,
+  TextStyle,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from "react-native";
 import { observer } from "mobx-react-lite";
 import { useLocalSearchParams, useRouter } from "expo-router";
 
@@ -16,7 +23,7 @@ import { Cell, Row } from "@common-ui/components/Common";
 import { SegmentControl } from "@common-ui/components/SegmentControl";
 import useGageChartOptions from "@utils/useGageChartOptions";
 import { UTC_ISO_FORMAT, formatUrlDate } from "@utils/urlDates";
-import { deriveRange, NOW_LITERAL } from "@utils/deriveRange";
+import { CHART_DEFAULT_RANGE_DAYS, deriveRange, NOW_LITERAL } from "@utils/deriveRange";
 import localDayJs from "@services/localDayJs";
 import { useStores } from "@models/helpers/useStores";
 import { useInterval } from "@utils/useTimeout";
@@ -24,7 +31,14 @@ import Config from "@config/config";
 import { IconButton, SolidButton } from "@common-ui/components/Button";
 import { Colors } from "@common-ui/constants/colors";
 import { Picker } from "@react-native-picker/picker";
-import { LabelText, MediumText, RegularText, SmallerText } from "@common-ui/components/Text";
+import {
+  LabelText,
+  MediumText,
+  MediumTitle,
+  RegularText,
+  SmallerText,
+  SmallTitle,
+} from "@common-ui/components/Text";
 import { FloodEvent } from "@models/LocationInfo";
 import { DataPoint } from "@models/Forecasts";
 import { formatReadingTime } from "@utils/useTimeFormat";
@@ -309,6 +323,41 @@ const CrestInfo = observer(function CrestInfo({ crest }: { crest: DataPoint }) {
   );
 });
 
+/** "Live" reset button — returns the chart to the default live window. */
+const LiveButton = observer(function LiveButton({ isNow }: { isNow: boolean }) {
+  const router = useRouter();
+  const { t } = useLocale();
+  const { isMobile } = useResponsive();
+
+  if (isNow) {
+    return null;
+  }
+
+  const TextComponent = isMobile ? SmallTitle : MediumTitle;
+
+  const handlePress = () => {
+    router.setParams({
+      historicEventId: undefined,
+      from: `-${CHART_DEFAULT_RANGE_DAYS}`,
+      to: NOW_LITERAL,
+    });
+  };
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      style={(state) => [
+        $liveButton,
+        state.pressed && $liveButtonPressed,
+        state.hovered && $liveButtonHovered,
+      ]}>
+      <TextComponent color={Colors.dark} align="center">
+        {t("forecastChart.live")}
+      </TextComponent>
+    </Pressable>
+  );
+});
+
 export const GageDetailsChart = observer(function GageDetailsChart(props: GageDetailsChartProps) {
   const { gage, hideChart } = props;
 
@@ -503,6 +552,7 @@ export const GageDetailsChart = observer(function GageDetailsChart(props: GageDe
           </Cell>
           <Cell flex align="flex-end">
             <If condition={!isMobile}>
+              <LiveButton isNow={range.isNow} />
               <DatePickerVariantSwitch
                 locationId={gage?.locationId}
                 startDate={range.chartStartDate}
@@ -515,16 +565,22 @@ export const GageDetailsChart = observer(function GageDetailsChart(props: GageDe
           </Cell>
         </Row>
         <If condition={isMobile}>
-          <Cell align="center" top={Spacing.tiny}>
-            <DatePickerVariantSwitch
-              locationId={gage?.locationId}
-              startDate={range.chartStartDate}
-              endDate={range.chartEndDate}
-              timezone={tz}
-              onChange={onDateRangeChange}
-              onRangeRestricted={() => setShowRangeWarning(true)}
-            />
-          </Cell>
+          <Row align="center" top={Spacing.tiny}>
+            <Cell flex />
+            <Cell>
+              <DatePickerVariantSwitch
+                locationId={gage?.locationId}
+                startDate={range.chartStartDate}
+                endDate={range.chartEndDate}
+                timezone={tz}
+                onChange={onDateRangeChange}
+                onRangeRestricted={() => setShowRangeWarning(true)}
+              />
+            </Cell>
+            <Cell flex align="flex-start">
+              <LiveButton isNow={range.isNow} />
+            </Cell>
+          </Row>
         </If>
       </CardHeader>
       {showRangeWarning && (
@@ -609,4 +665,21 @@ const $bottomSheetStyle: ViewStyle = {
     width: 0,
     height: -4,
   },
+};
+
+const $liveButton: ViewStyle = {
+  paddingHorizontal: Spacing.extraSmall,
+  paddingVertical: Spacing.extraSmall,
+  backgroundColor: "transparent",
+  borderRadius: Spacing.extraSmall,
+};
+
+const $liveButtonPressed: ViewStyle = {
+  backgroundColor: Colors.lightGrey,
+  opacity: 0.8,
+};
+
+const $liveButtonHovered: ViewStyle = {
+  backgroundColor: Colors.lightGrey,
+  opacity: 0.8,
 };

--- a/src/components/__tests__/GageDetailsChart.date-sync.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.date-sync.test.tsx
@@ -99,8 +99,6 @@ jest.mock("@common-ui/components/Text", () => ({
   RegularText: () => null,
   SmallerText: () => null,
   LabelText: () => null,
-  MediumTitle: () => null,
-  SmallTitle: () => null,
 }));
 jest.mock("@utils/navigation", () => ({
   normalizeSearchParams: (v: string | string[]) => (Array.isArray(v) ? v.join(", ") : v),

--- a/src/components/__tests__/GageDetailsChart.date-sync.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.date-sync.test.tsx
@@ -99,6 +99,8 @@ jest.mock("@common-ui/components/Text", () => ({
   RegularText: () => null,
   SmallerText: () => null,
   LabelText: () => null,
+  MediumTitle: () => null,
+  SmallTitle: () => null,
 }));
 jest.mock("@utils/navigation", () => ({
   normalizeSearchParams: (v: string | string[]) => (Array.isArray(v) ? v.join(", ") : v),

--- a/src/components/__tests__/GageDetailsChart.date-sync.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.date-sync.test.tsx
@@ -60,6 +60,9 @@ jest.mock("@common-ui/utils/responsive", () => ({
   isIOS: false,
   isMobile: false,
 }));
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
 jest.mock("@gorhom/bottom-sheet", () => ({
   BottomSheetModal: () => null,
   BottomSheetView: ({ children }: any) => children,

--- a/src/components/__tests__/GageDetailsChart.event-reset.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.event-reset.test.tsx
@@ -1,0 +1,184 @@
+// src/components/__tests__/GageDetailsChart.event-reset.test.tsx
+import React from "react";
+import { render, act } from "@testing-library/react-native";
+import { GageDetailsChart } from "../GageDetailsChart";
+
+// --- Mocks ---
+const mockParamsBox: {
+  current: { from?: string; to?: string; historicEventId?: string };
+} = { current: {} };
+const mockSetParams = jest.fn();
+
+let capturedPickerSelectedValue: any = undefined;
+
+jest.mock("@common-ui/components/SegmentControl", () => ({
+  SegmentControl: () => null,
+}));
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => mockParamsBox.current,
+  useRouter: () => ({ setParams: mockSetParams }),
+}));
+
+jest.mock("@models/helpers/useStores", () => ({
+  useStores: () => ({
+    isDataFetched: true,
+    getTimezone: () => "America/Los_Angeles",
+    gagesStore: { fetchDataForGage: jest.fn(), isFetching: false },
+  }),
+}));
+
+jest.mock("@common-ui/contexts/DatePickerContext", () => ({
+  useDatePicker: () => ({ isVisible: false, showPicker: jest.fn(), hidePicker: jest.fn() }),
+}));
+
+jest.mock("@services/highcharts/LocalHighchartsReact", () => () => null);
+jest.mock("@services/highcharts/HighchartsReactNative", () => () => null);
+jest.mock("../GageDetailsChartNative", () => ({ GageDetailsChartNative: () => null }));
+jest.mock("@utils/useGageChartOptions", () => ({ __esModule: true, default: () => [{}, null] }));
+jest.mock("@utils/useTimeout", () => ({ useTimeout: jest.fn(), useInterval: jest.fn() }));
+jest.mock("@common-ui/contexts/LocaleContext", () => ({
+  useLocale: () => ({ t: (k: string) => k }),
+}));
+jest.mock("@common-ui/utils/responsive", () => ({
+  useResponsive: () => ({ isMobile: false }),
+  isAndroid: false,
+  isIOS: false,
+  isMobile: false,
+  MobileScreen: () => null,
+  WideScreen: () => null,
+}));
+jest.mock("@gorhom/bottom-sheet", () => ({
+  BottomSheetModal: () => null,
+  BottomSheetView: ({ children }: any) => children,
+}));
+jest.mock("@react-native-picker/picker", () => {
+  function PickerMock(props: any) {
+    capturedPickerSelectedValue = props.selectedValue;
+    return null;
+  }
+  function PickerItem() {
+    return null;
+  }
+  PickerMock.Item = PickerItem;
+  return { Picker: PickerMock };
+});
+jest.mock("../DatePickerVariantSwitch", () => () => null);
+jest.mock("@common-ui/components/Icon", () => () => null);
+jest.mock("@common-ui/components/Card", () => {
+  const React = require("react");
+  const Pass = ({ children }: any) => React.createElement(React.Fragment, null, children ?? null);
+  return { Card: Pass, CardHeader: Pass, CardFooter: Pass };
+});
+jest.mock("@common-ui/components/Common", () => {
+  const React = require("react");
+  const Pass = ({ children }: any) => React.createElement(React.Fragment, null, children ?? null);
+  return { Row: Pass, Cell: Pass, RowOrCell: Pass };
+});
+jest.mock("@common-ui/components/Conditional", () => {
+  const React = require("react");
+  return {
+    If: ({ condition, children }: any) =>
+      condition ? React.createElement(React.Fragment, null, children) : null,
+    Ternary: ({ condition, children }: any) => {
+      const arr = React.Children.toArray(children);
+      return condition ? arr[0] ?? null : arr[1] ?? null;
+    },
+  };
+});
+jest.mock("@common-ui/components/Button", () => ({
+  IconButton: () => null,
+  SolidButton: () => null,
+}));
+jest.mock("@common-ui/components/Text", () => ({
+  MediumText: () => null,
+  RegularText: () => null,
+  SmallerText: () => null,
+  LabelText: () => null,
+}));
+jest.mock("@utils/navigation", () => ({
+  normalizeSearchParams: (v: string | string[]) => (Array.isArray(v) ? v.join(", ") : v),
+}));
+jest.mock("@utils/useTimeFormat", () => ({ formatReadingTime: (ts: string) => ts }));
+jest.mock("@config/config", () => ({
+  default: { LIVE_CHART_DATA_REFRESH_INTERVAL: 60000, GAGES_WITHOUT_DISHCARGE: [] },
+}));
+
+const SELECT_EVENT = "gageDetailsChart._selectEvent";
+
+const mockGage: any = {
+  locationId: "USGS-NF10",
+  locationInfo: {
+    floodEvents: [
+      { id: 5, eventName: "Feb 2020 Flood", fromDate: "2020-02-04", toDate: "2020-02-13" },
+      { id: 6, eventName: "Jan 2022 Flood", fromDate: "2022-01-05", toDate: "2022-01-12" },
+    ],
+    hasDischarge: false,
+    locationName: "North Fork Snoqualmie River",
+    dischargeMin: 0,
+    dischargeMax: 0,
+    yMin: 0,
+    yMax: 20,
+  },
+  readings: [],
+  actualReadings: [],
+  predictions: [],
+  predictedFeetPerHour: 0,
+  predictedCfsPerHour: 0,
+  dataPoints: [],
+  actualPoints: [],
+  predictedPoints: [],
+  noaaForecastData: [],
+  hasData: false,
+};
+
+describe("GageDetailsChart — historic event picker resets when range changes", () => {
+  beforeEach(() => {
+    mockParamsBox.current = {};
+    mockSetParams.mockClear();
+    capturedPickerSelectedValue = undefined;
+  });
+
+  it("Picker reflects the historicEventId from the URL", () => {
+    mockParamsBox.current = {
+      from: "2020-02-04",
+      to: "2020-02-13",
+      historicEventId: "5",
+    };
+    render(<GageDetailsChart gage={mockGage} />);
+    expect(capturedPickerSelectedValue).toBe("5");
+  });
+
+  it("Picker resets to SELECT_EVENT when URL clears historicEventId (range change)", async () => {
+    mockParamsBox.current = {
+      from: "2020-02-04",
+      to: "2020-02-13",
+      historicEventId: "5",
+    };
+    const { rerender } = render(<GageDetailsChart gage={mockGage} />);
+    expect(capturedPickerSelectedValue).toBe("5");
+
+    // Simulate a range change that clears historicEventId in the URL.
+    // Pass a new floodEvents array reference so the HistoricEvents observer re-renders
+    // (MobX observer bails out if props are referentially equal).
+    mockParamsBox.current = { from: "-7", to: "now" };
+    const updatedGage = {
+      ...mockGage,
+      locationInfo: {
+        ...mockGage.locationInfo,
+        floodEvents: [...mockGage.locationInfo.floodEvents],
+      },
+    };
+    await act(async () => {
+      rerender(<GageDetailsChart gage={updatedGage} />);
+    });
+
+    expect(capturedPickerSelectedValue).toBe(SELECT_EVENT);
+  });
+
+  it("Picker shows SELECT_EVENT on cold-load (no params)", () => {
+    mockParamsBox.current = {};
+    render(<GageDetailsChart gage={mockGage} />);
+    expect(capturedPickerSelectedValue).toBe(SELECT_EVENT);
+  });
+});

--- a/src/components/__tests__/GageDetailsChart.event-reset.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.event-reset.test.tsx
@@ -48,6 +48,9 @@ jest.mock("@common-ui/utils/responsive", () => ({
   MobileScreen: () => null,
   WideScreen: () => null,
 }));
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
 jest.mock("@gorhom/bottom-sheet", () => ({
   BottomSheetModal: () => null,
   BottomSheetView: ({ children }: any) => children,

--- a/src/components/__tests__/GageDetailsChart.event-reset.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.event-reset.test.tsx
@@ -142,7 +142,7 @@ describe("GageDetailsChart — historic event picker resets when range changes",
     capturedPickerSelectedValue = undefined;
   });
 
-  it("Picker reflects the historicEventId from the URL", () => {
+  test("Picker reflects the historicEventId from the URL", () => {
     mockParamsBox.current = {
       from: "2020-02-04",
       to: "2020-02-13",
@@ -152,7 +152,7 @@ describe("GageDetailsChart — historic event picker resets when range changes",
     expect(capturedPickerSelectedValue).toBe("5");
   });
 
-  it("Picker resets to SELECT_EVENT when URL clears historicEventId (range change)", async () => {
+  test("Picker resets to SELECT_EVENT when URL clears historicEventId (range change)", async () => {
     mockParamsBox.current = {
       from: "2020-02-04",
       to: "2020-02-13",
@@ -179,7 +179,7 @@ describe("GageDetailsChart — historic event picker resets when range changes",
     expect(capturedPickerSelectedValue).toBe(SELECT_EVENT);
   });
 
-  it("Picker shows SELECT_EVENT on cold-load (no params)", () => {
+  test("Picker shows SELECT_EVENT on cold-load (no params)", () => {
     mockParamsBox.current = {};
     render(<GageDetailsChart gage={mockGage} />);
     expect(capturedPickerSelectedValue).toBe(SELECT_EVENT);

--- a/src/components/__tests__/GageDetailsChart.historical.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.historical.test.tsx
@@ -111,6 +111,8 @@ jest.mock("@common-ui/components/Text", () => ({
   RegularText: () => null,
   SmallerText: () => null,
   LabelText: () => null,
+  MediumTitle: () => null,
+  SmallTitle: () => null,
 }));
 
 jest.mock("@utils/navigation", () => ({

--- a/src/components/__tests__/GageDetailsChart.historical.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.historical.test.tsx
@@ -111,8 +111,6 @@ jest.mock("@common-ui/components/Text", () => ({
   RegularText: () => null,
   SmallerText: () => null,
   LabelText: () => null,
-  MediumTitle: () => null,
-  SmallTitle: () => null,
 }));
 
 jest.mock("@utils/navigation", () => ({

--- a/src/components/__tests__/GageDetailsChart.historical.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.historical.test.tsx
@@ -60,6 +60,9 @@ jest.mock("@common-ui/utils/responsive", () => ({
   WideScreen: () => null,
 }));
 
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
 jest.mock("@gorhom/bottom-sheet", () => ({
   BottomSheetModal: () => null,
   BottomSheetView: ({ children }: any) => children,

--- a/src/components/__tests__/GageDetailsChart.live-button.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.live-button.test.tsx
@@ -162,7 +162,7 @@ describe("GageDetailsChart — Live segment", () => {
     expect(keys).toEqual(["14", "7", "2", "1", "live"]);
   });
 
-  it("selecting the live segment resets URL to from=-2 / to=now and clears historicEventId", async () => {
+  it("resets the URL properly when selecting the live segment", async () => {
     mockParamsBox.current = { from: "2020-02-04", to: "2020-02-13" };
     render(<GageDetailsChart gage={mockGage} />);
 

--- a/src/components/__tests__/GageDetailsChart.live-button.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.live-button.test.tsx
@@ -1,6 +1,6 @@
 // src/components/__tests__/GageDetailsChart.live-button.test.tsx
 import React from "react";
-import { render, fireEvent } from "@testing-library/react-native";
+import { render, act } from "@testing-library/react-native";
 import { GageDetailsChart } from "../GageDetailsChart";
 
 // --- Mocks ---
@@ -9,8 +9,14 @@ const mockParamsBox: { current: { from?: string; to?: string; historicEventId?: 
 };
 const mockSetParams = jest.fn();
 
+let capturedSegments: { key: string; title: string }[] | undefined;
+let capturedRangeOnChange: ((key: string) => void) | undefined;
 jest.mock("@common-ui/components/SegmentControl", () => ({
-  SegmentControl: () => null,
+  SegmentControl: ({ segments, onChange }: any) => {
+    capturedSegments = segments;
+    capturedRangeOnChange = onChange;
+    return null;
+  },
 }));
 
 jest.mock("expo-router", () => ({
@@ -87,20 +93,12 @@ jest.mock("@common-ui/components/Button", () => ({
   IconButton: () => null,
   SolidButton: () => null,
 }));
-jest.mock("@common-ui/components/Text", () => {
-  const React = require("react");
-  const RN = require("react-native");
-  const Pass = ({ children }: any) =>
-    React.createElement(RN.Text, null, typeof children === "string" ? children : null);
-  return {
-    MediumText: () => null,
-    RegularText: () => null,
-    SmallerText: () => null,
-    LabelText: () => null,
-    SmallTitle: Pass,
-    MediumTitle: Pass,
-  };
-});
+jest.mock("@common-ui/components/Text", () => ({
+  MediumText: () => null,
+  RegularText: () => null,
+  SmallerText: () => null,
+  LabelText: () => null,
+}));
 jest.mock("@utils/navigation", () => ({
   normalizeSearchParams: (v: string | string[]) => (Array.isArray(v) ? v.join(", ") : v),
 }));
@@ -132,35 +130,42 @@ const mockGage: any = {
   hasData: false,
 };
 
-describe("GageDetailsChart — Live button", () => {
+describe("GageDetailsChart — Live segment", () => {
   beforeEach(() => {
     mockParamsBox.current = {};
     mockSetParams.mockClear();
+    capturedSegments = undefined;
+    capturedRangeOnChange = undefined;
   });
 
-  it("does not render the Live button in live mode (to=now)", () => {
+  it("omits the live segment when range.isNow is true (to=now)", () => {
     mockParamsBox.current = { from: "-2", to: "now" };
-    const { queryByText } = render(<GageDetailsChart gage={mockGage} />);
-    expect(queryByText("forecastChart.live")).toBeNull();
+    render(<GageDetailsChart gage={mockGage} />);
+    const keys = capturedSegments?.map((s) => s.key);
+    expect(keys).toEqual(["14", "7", "2", "1"]);
   });
 
-  it("does not render the Live button on cold-load (no params → live default)", () => {
+  it("omits the live segment on cold-load (no params → live default)", () => {
     mockParamsBox.current = {};
-    const { queryByText } = render(<GageDetailsChart gage={mockGage} />);
-    expect(queryByText("forecastChart.live")).toBeNull();
+    render(<GageDetailsChart gage={mockGage} />);
+    const keys = capturedSegments?.map((s) => s.key);
+    expect(keys).toEqual(["14", "7", "2", "1"]);
   });
 
-  it("renders the Live button when range is historic", () => {
+  it("includes the live segment as the last item when in historic mode", () => {
     mockParamsBox.current = { from: "2020-02-04", to: "2020-02-13" };
-    const { getByText } = render(<GageDetailsChart gage={mockGage} />);
-    expect(getByText("forecastChart.live")).toBeTruthy();
+    render(<GageDetailsChart gage={mockGage} />);
+    const keys = capturedSegments?.map((s) => s.key);
+    expect(keys).toEqual(["14", "7", "2", "1", "live"]);
   });
 
-  it("pressing Live resets URL to from=-2 / to=now and clears historicEventId", () => {
+  it("selecting the live segment resets URL to from=-2 / to=now and clears historicEventId", async () => {
     mockParamsBox.current = { from: "2020-02-04", to: "2020-02-13" };
-    const { getByText } = render(<GageDetailsChart gage={mockGage} />);
+    render(<GageDetailsChart gage={mockGage} />);
 
-    fireEvent.press(getByText("forecastChart.live"));
+    await act(async () => {
+      capturedRangeOnChange?.("live");
+    });
 
     expect(mockSetParams).toHaveBeenCalledWith({
       historicEventId: undefined,

--- a/src/components/__tests__/GageDetailsChart.live-button.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.live-button.test.tsx
@@ -1,0 +1,171 @@
+// src/components/__tests__/GageDetailsChart.live-button.test.tsx
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import { GageDetailsChart } from "../GageDetailsChart";
+
+// --- Mocks ---
+const mockParamsBox: { current: { from?: string; to?: string; historicEventId?: string } } = {
+  current: {},
+};
+const mockSetParams = jest.fn();
+
+jest.mock("@common-ui/components/SegmentControl", () => ({
+  SegmentControl: () => null,
+}));
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => mockParamsBox.current,
+  useRouter: () => ({ setParams: mockSetParams }),
+}));
+
+jest.mock("@models/helpers/useStores", () => ({
+  useStores: () => ({
+    isDataFetched: true,
+    getTimezone: () => "America/Los_Angeles",
+    gagesStore: { fetchDataForGage: jest.fn(), isFetching: false },
+  }),
+}));
+
+jest.mock("@common-ui/contexts/DatePickerContext", () => ({
+  useDatePicker: () => ({ isVisible: false, showPicker: jest.fn(), hidePicker: jest.fn() }),
+}));
+
+jest.mock("@services/highcharts/LocalHighchartsReact", () => () => null);
+jest.mock("@services/highcharts/HighchartsReactNative", () => () => null);
+jest.mock("../GageDetailsChartNative", () => ({ GageDetailsChartNative: () => null }));
+jest.mock("@utils/useGageChartOptions", () => ({ __esModule: true, default: () => [{}, null] }));
+jest.mock("@utils/useTimeout", () => ({ useTimeout: jest.fn(), useInterval: jest.fn() }));
+jest.mock("@common-ui/contexts/LocaleContext", () => ({
+  useLocale: () => ({ t: (k: string) => k }),
+}));
+jest.mock("@common-ui/utils/responsive", () => ({
+  useResponsive: () => ({ isMobile: false }),
+  isAndroid: false,
+  isIOS: false,
+  isMobile: false,
+  MobileScreen: () => null,
+  WideScreen: () => null,
+}));
+jest.mock("@gorhom/bottom-sheet", () => ({
+  BottomSheetModal: () => null,
+  BottomSheetView: ({ children }: any) => children,
+}));
+jest.mock("@react-native-picker/picker", () => {
+  function PickerMock() {
+    return null;
+  }
+  function PickerItem() {
+    return null;
+  }
+  PickerMock.Item = PickerItem;
+  return { Picker: PickerMock };
+});
+jest.mock("../DatePickerVariantSwitch", () => () => null);
+jest.mock("@common-ui/components/Icon", () => () => null);
+jest.mock("@common-ui/components/Card", () => {
+  const React = require("react");
+  const Pass = ({ children }: any) => React.createElement(React.Fragment, null, children ?? null);
+  return { Card: Pass, CardHeader: Pass, CardFooter: Pass };
+});
+jest.mock("@common-ui/components/Common", () => {
+  const React = require("react");
+  const Pass = ({ children }: any) => React.createElement(React.Fragment, null, children ?? null);
+  return { Row: Pass, Cell: Pass, RowOrCell: Pass };
+});
+jest.mock("@common-ui/components/Conditional", () => {
+  const React = require("react");
+  return {
+    If: ({ condition, children }: any) =>
+      condition ? React.createElement(React.Fragment, null, children) : null,
+    Ternary: ({ condition, children }: any) => {
+      const arr = React.Children.toArray(children);
+      return condition ? arr[0] ?? null : arr[1] ?? null;
+    },
+  };
+});
+jest.mock("@common-ui/components/Button", () => ({
+  IconButton: () => null,
+  SolidButton: () => null,
+}));
+jest.mock("@common-ui/components/Text", () => {
+  const React = require("react");
+  const RN = require("react-native");
+  const Pass = ({ children }: any) =>
+    React.createElement(RN.Text, null, typeof children === "string" ? children : null);
+  return {
+    MediumText: () => null,
+    RegularText: () => null,
+    SmallerText: () => null,
+    LabelText: () => null,
+    SmallTitle: Pass,
+    MediumTitle: Pass,
+  };
+});
+jest.mock("@utils/navigation", () => ({
+  normalizeSearchParams: (v: string | string[]) => (Array.isArray(v) ? v.join(", ") : v),
+}));
+jest.mock("@utils/useTimeFormat", () => ({ formatReadingTime: (ts: string) => ts }));
+jest.mock("@config/config", () => ({
+  default: { LIVE_CHART_DATA_REFRESH_INTERVAL: 60000, GAGES_WITHOUT_DISHCARGE: [] },
+}));
+
+const mockGage: any = {
+  locationId: "USGS-NF10",
+  locationInfo: {
+    floodEvents: [],
+    hasDischarge: false,
+    locationName: "North Fork Snoqualmie River",
+    dischargeMin: 0,
+    dischargeMax: 0,
+    yMin: 0,
+    yMax: 20,
+  },
+  readings: [],
+  actualReadings: [],
+  predictions: [],
+  predictedFeetPerHour: 0,
+  predictedCfsPerHour: 0,
+  dataPoints: [],
+  actualPoints: [],
+  predictedPoints: [],
+  noaaForecastData: [],
+  hasData: false,
+};
+
+describe("GageDetailsChart — Live button", () => {
+  beforeEach(() => {
+    mockParamsBox.current = {};
+    mockSetParams.mockClear();
+  });
+
+  it("does not render the Live button in live mode (to=now)", () => {
+    mockParamsBox.current = { from: "-2", to: "now" };
+    const { queryByText } = render(<GageDetailsChart gage={mockGage} />);
+    expect(queryByText("forecastChart.live")).toBeNull();
+  });
+
+  it("does not render the Live button on cold-load (no params → live default)", () => {
+    mockParamsBox.current = {};
+    const { queryByText } = render(<GageDetailsChart gage={mockGage} />);
+    expect(queryByText("forecastChart.live")).toBeNull();
+  });
+
+  it("renders the Live button when range is historic", () => {
+    mockParamsBox.current = { from: "2020-02-04", to: "2020-02-13" };
+    const { getByText } = render(<GageDetailsChart gage={mockGage} />);
+    expect(getByText("forecastChart.live")).toBeTruthy();
+  });
+
+  it("pressing Live resets URL to from=-2 / to=now and clears historicEventId", () => {
+    mockParamsBox.current = { from: "2020-02-04", to: "2020-02-13" };
+    const { getByText } = render(<GageDetailsChart gage={mockGage} />);
+
+    fireEvent.press(getByText("forecastChart.live"));
+
+    expect(mockSetParams).toHaveBeenCalledWith({
+      historicEventId: undefined,
+      from: "-2",
+      to: "now",
+    });
+  });
+});

--- a/src/components/__tests__/GageDetailsChart.live-button.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.live-button.test.tsx
@@ -52,6 +52,9 @@ jest.mock("@common-ui/utils/responsive", () => ({
   MobileScreen: () => null,
   WideScreen: () => null,
 }));
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
 jest.mock("@gorhom/bottom-sheet", () => ({
   BottomSheetModal: () => null,
   BottomSheetView: ({ children }: any) => children,

--- a/src/components/__tests__/GageDetailsChart.picker-dismiss.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.picker-dismiss.test.tsx
@@ -92,6 +92,8 @@ jest.mock("@common-ui/components/Text", () => ({
   RegularText: () => null,
   SmallerText: () => null,
   LabelText: () => null,
+  MediumTitle: () => null,
+  SmallTitle: () => null,
 }));
 jest.mock("@utils/navigation", () => ({
   normalizeSearchParams: (v: string | string[]) => (Array.isArray(v) ? v.join(", ") : v),

--- a/src/components/__tests__/GageDetailsChart.picker-dismiss.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.picker-dismiss.test.tsx
@@ -92,8 +92,6 @@ jest.mock("@common-ui/components/Text", () => ({
   RegularText: () => null,
   SmallerText: () => null,
   LabelText: () => null,
-  MediumTitle: () => null,
-  SmallTitle: () => null,
 }));
 jest.mock("@utils/navigation", () => ({
   normalizeSearchParams: (v: string | string[]) => (Array.isArray(v) ? v.join(", ") : v),

--- a/src/components/__tests__/GageDetailsChart.picker-dismiss.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.picker-dismiss.test.tsx
@@ -49,6 +49,9 @@ jest.mock("@common-ui/utils/responsive", () => ({
   MobileScreen: () => null,
   WideScreen: () => null,
 }));
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
 jest.mock("@gorhom/bottom-sheet", () => ({
   BottomSheetModal: () => null,
   BottomSheetView: ({ children }: any) => children,

--- a/src/components/__tests__/GageDetailsChart.range-highlight.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.range-highlight.test.tsx
@@ -97,8 +97,6 @@ jest.mock("@common-ui/components/Text", () => ({
   RegularText: () => null,
   SmallerText: () => null,
   LabelText: () => null,
-  MediumTitle: () => null,
-  SmallTitle: () => null,
 }));
 jest.mock("@utils/navigation", () => ({
   normalizeSearchParams: (v: string | string[]) => (Array.isArray(v) ? v.join(", ") : v),

--- a/src/components/__tests__/GageDetailsChart.range-highlight.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.range-highlight.test.tsx
@@ -97,6 +97,8 @@ jest.mock("@common-ui/components/Text", () => ({
   RegularText: () => null,
   SmallerText: () => null,
   LabelText: () => null,
+  MediumTitle: () => null,
+  SmallTitle: () => null,
 }));
 jest.mock("@utils/navigation", () => ({
   normalizeSearchParams: (v: string | string[]) => (Array.isArray(v) ? v.join(", ") : v),

--- a/src/components/__tests__/GageDetailsChart.range-highlight.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.range-highlight.test.tsx
@@ -51,6 +51,9 @@ jest.mock("@common-ui/utils/responsive", () => ({
   MobileScreen: () => null,
   WideScreen: () => null,
 }));
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
 jest.mock("@gorhom/bottom-sheet", () => ({
   BottomSheetModal: () => null,
   BottomSheetView: ({ children }: any) => children,

--- a/src/components/__tests__/GageDetailsChart.range-shortcut-stale.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.range-shortcut-stale.test.tsx
@@ -62,6 +62,9 @@ jest.mock("@common-ui/utils/responsive", () => ({
   MobileScreen: () => null,
   WideScreen: () => null,
 }));
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
 jest.mock("@gorhom/bottom-sheet", () => ({
   BottomSheetModal: () => null,
   BottomSheetView: ({ children }: any) => children,

--- a/src/components/__tests__/GageDetailsChart.range-shortcut.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.range-shortcut.test.tsx
@@ -96,6 +96,8 @@ jest.mock("@common-ui/components/Text", () => ({
   RegularText: () => null,
   SmallerText: () => null,
   LabelText: () => null,
+  MediumTitle: () => null,
+  SmallTitle: () => null,
 }));
 jest.mock("@utils/navigation", () => ({
   normalizeSearchParams: (v: string | string[]) => (Array.isArray(v) ? v.join(", ") : v),

--- a/src/components/__tests__/GageDetailsChart.range-shortcut.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.range-shortcut.test.tsx
@@ -96,8 +96,6 @@ jest.mock("@common-ui/components/Text", () => ({
   RegularText: () => null,
   SmallerText: () => null,
   LabelText: () => null,
-  MediumTitle: () => null,
-  SmallTitle: () => null,
 }));
 jest.mock("@utils/navigation", () => ({
   normalizeSearchParams: (v: string | string[]) => (Array.isArray(v) ? v.join(", ") : v),

--- a/src/components/__tests__/GageDetailsChart.range-shortcut.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.range-shortcut.test.tsx
@@ -50,6 +50,9 @@ jest.mock("@common-ui/utils/responsive", () => ({
   MobileScreen: () => null,
   WideScreen: () => null,
 }));
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
 jest.mock("@gorhom/bottom-sheet", () => ({
   BottomSheetModal: () => null,
   BottomSheetView: ({ children }: any) => children,

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -235,6 +235,7 @@ const en = {
     fullRangeTitle: "Full",
     rangeDays: "{{days}} days",
     rangeDay: "day",
+    live: "Live",
   },
   gageChart: {
     discharge: "Discharge",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -239,6 +239,7 @@ const es = {
     fullRangeTitle: "Completo",
     rangeDays: "{{days}} días",
     rangeDay: "día",
+    live: "En vivo",
   },
   gageChart: {
     discharge: "Descarga",


### PR DESCRIPTION
## Summary

Adds a "Live" shortcut to the gage details chart range picker and fixes two related historic-event picker bugs.

### Live shortcut

A new **"Live"** item is appended to the existing range-shortcut row (after **1 day**) whenever the chart is in historic mode. Pressing it resets the URL to the default live window (`from=-2`, `to=now`). When the chart is already live, the Live item is hidden so the row stays uncluttered. Renders the same way on mobile and desktop, no separate platform layout. Localized: **Live** / **En vivo**.

### Historic event picker now resets on range change

Previously, after picking a historic event, changing the date range (via shortcuts, the date picker, or the new Live button) would leave the event selector visually stuck on the previously-chosen event — even though all range handlers were correctly clearing `historicEventId` in the URL. The bug was inside `HistoricEvents`:

- The iOS bottom-sheet held stale local `selectedEvent` state that was never synced back from the URL.
- The non-iOS `<Picker>` was passed `selectedValue={undefined}` when no event was selected, which doesn't reliably show the default item on Android/web.

Fix: derive `urlEventId` from the URL, sync the local state via `useEffect`, and default the Picker's `selectedValue` to the `SELECT_EVENT` sentinel when no event is in the URL.

### iOS bottom-sheet Confirm button tap target

The historic-event bottom sheet (`detached={true}`, `snapPoints={["40%"]}`) placed the Confirm button right against the home indicator on iPhone, making it hard to tap. Bumped the snap point to `50%` and added `useSafeAreaInsets` so the sheet now reserves `insets.bottom + Spacing.medium` of bottom padding.

## Test plan

- [ ] Open a gage details chart in live mode → range row shows `14 days / 7 days / 2 days / 1 day` centered, no Live segment
- [ ] Pick a historic date range via the date picker → range row shows `… / 1 day / Live`, still centered
- [ ] Tap **Live** → chart returns to default 2-day live window, Live segment disappears
- [ ] Switch app language to Spanish → segment reads **En vivo**
- [ ] Pick a historic event, then change the range via a shortcut → event selector resets to "Select event" (verify on iOS, Android, and web)
- [ ] On iPhone: open the historic-event picker → Confirm button sits clearly above the home indicator with comfortable tap room
- [ ] `npx jest src/components/__tests__/GageDetailsChart` → 37/37 pass
- [ ] `npx tsc --noEmit` → no new errors
