### PR TITLE
Feat: region summary card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,3 +174,14 @@ This applies in three directions:
 - **Construction:** when building a Dayjs from a date string in code (in components, stores, tests), construct it in gauge tz from the start: `localDayJs.tz("2026-05-01", "YYYY-MM-DD", timezone)`. A bare `dayjs("2026-05-01")` is midnight in the _system_ tz and will silently produce the wrong day when system tz != gauge tz.
 
 **Testing:** the Jest suite runs with `TZ=UTC` so any code that silently relies on system tz matching gauge tz will fail in tests. When writing tz-sensitive tests, never construct dates with bare `dayjs(string)` or `new Date(string)` — always specify the tz explicitly.
+
+### Localization
+
+All user-visible strings go through the `useLocale()` hook (`t("key")`). Translation files live in `src/i18n/`. `LocaleContext.tsx` wraps the app at the root level.
+
+- +**Spanish (`es.ts`) conventions** — see [docs/spanish-translation-review.md](docs/spanish-translation-review.md) for the full review and rationale:
+  +- Audience is the local Latino community (predominantly Mexican-origin) → use **Latin American Spanish, informal `tú` register**. Avoid peninsular forms (`vale`, `vosotros`) and `usted` imperatives. Don't mix registers within a screen.
+  +- For hydrology, river flow/discharge is **`caudal`**, not `descarga` (which means "download" in everyday Spanish) or `flujo` (flow).
+  +- For OS-style labels (login, about, settings), match Apple/Google Spanish localizations (e.g. `Iniciar sesión`, `Acerca de`).
+  +- Spanish requires paired punctuation: `¡...!` and `¿...?` — both marks, not just the closing one.
+  +- UI labels omit leading definite articles (`Medidor río arriba`, not `El medidor río arriba`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,10 @@ EXPO_TUNNEL_SUBDOMAIN="floodzuki" npx expo start --tunnel --web
 - **Highcharts** (web) and **Victory Native** (mobile) for charts — the chart components are split by platform
 - **i18n-js** for localization with `dayjs` for date/time
 
+### TypeScript conventions
+
+- For closed sets of string values, prefer **string enums** (`enum Severity { None = "none", ... }`) over string-literal union types (`type Severity = "none" | ...`). Enables `Severity.None` comparisons and a single source of truth across stores, components, and tests.
+
 ### Directory structure
 
 ```

--- a/app/(root)/gage/[id].tsx
+++ b/app/(root)/gage/[id].tsx
@@ -186,6 +186,18 @@ const GageDetailsScreen = observer(function GageDetailsScreen({ gage }: { gage: 
       </MobileScreen>
       {/* Content */}
       <Content scrollable onRefresh={() => gagesStore.fetchData}>
+        <If
+          condition={
+            !!gage?._isStub || (gage?.gageStatus?.floodLevel === "Offline" && !gage?.hasData)
+          }>
+          <Card
+            bottom={Spacing.small}
+            innerHorizontal={Spacing.medium}
+            innerVertical={Spacing.small}
+            backgroundColor={Colors.softYellow}>
+            <RegularText color={Colors.warning}>{t("regionSummary.offlineBanner")}</RegularText>
+          </Card>
+        </If>
         <GageDetailsChart gage={gage} />
         <Row>
           <If condition={!isMobile}>

--- a/app/(root)/gage/[id].tsx
+++ b/app/(root)/gage/[id].tsx
@@ -186,18 +186,6 @@ const GageDetailsScreen = observer(function GageDetailsScreen({ gage }: { gage: 
       </MobileScreen>
       {/* Content */}
       <Content scrollable onRefresh={() => gagesStore.fetchData}>
-        <If
-          condition={
-            !!gage?._isStub || (gage?.gageStatus?.floodLevel === "Offline" && !gage?.hasData)
-          }>
-          <Card
-            bottom={Spacing.small}
-            innerHorizontal={Spacing.medium}
-            innerVertical={Spacing.small}
-            backgroundColor={Colors.softYellow}>
-            <RegularText color={Colors.warning}>{t("regionSummary.offlineBanner")}</RegularText>
-          </Card>
-        </If>
         <GageDetailsChart gage={gage} />
         <Row>
           <If condition={!isMobile}>

--- a/app/(root)/gage/index.tsx
+++ b/app/(root)/gage/index.tsx
@@ -168,8 +168,23 @@ const HeaderComponent = ({ gages, region }: { gages: Gage[]; region: Region }) =
 };
 
 const keyExtractor = (item: Gage) => item?.locationId;
-const renderGageItem = ({ item }: { item: Gage }) =>
-  item?._isStub ? <HiddenGageItem item={item} /> : <GageItem item={item} />;
+const renderGageItem = ({ item }: { item: Gage }) => {
+  if (item?._isStub) {
+    // Pass a plain-JS POJO to HiddenGageItem so React DevTools' commit-phase prop
+    // traversal never sees an MST proxy (which can trip MST 7's "initializing phase"
+    // assertion on lazy empty-array children). See mobx-state-tree#2279 and the comment
+    // on the HiddenStubItem type for the full story.
+    return (
+      <HiddenGageItem
+        item={{
+          locationId: item.locationId,
+          locationName: item.locationInfo?.locationName,
+        }}
+      />
+    );
+  }
+  return <GageItem item={item} />;
+};
 const getItemLayout = (data: Gage[], index: number) => ({
   length: ITEM_HEIGHT,
   offset: ITEM_HEIGHT * index,

--- a/app/(root)/gage/index.tsx
+++ b/app/(root)/gage/index.tsx
@@ -28,11 +28,13 @@ import { useUtils } from "@utils/utils";
 import { formatReadingTime } from "@utils/useTimeFormat";
 import { ROUTES } from "app/_layout";
 import TrendIcon, { TREND_ICON_TYPES } from "@components/TrendIcon";
-import { useInterval, useTimeout } from "@utils/useTimeout";
+import { useInterval } from "@utils/useTimeout";
 import EmptyComponent from "@common-ui/components/EmptyComponent";
 import { GageChart } from "@components/GageChart";
 import GageMap from "@components/GageMap";
 import GageListItemChart from "@components/GageListItemChart";
+import RegionSummaryCard from "@components/RegionSummaryCard";
+import HiddenGageItem from "@components/HiddenGageItem";
 import WebFooter from "@components/WebFooter";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
 import { TxKeyPath } from "@i18n/i18n";
@@ -142,27 +144,32 @@ const HeaderComponent = ({ gages, region }: { gages: Gage[]; region: Region }) =
   const router = useRouter();
 
   return (
-    <If condition={isMobile}>
-      <Card
-        height={300}
-        innerHorizontal={Spacing.tiny}
-        innerVertical={Spacing.tiny}
-        bottom={Spacing.small}>
-        <GageMap
-          gages={gages || []}
-          region={region}
-          onGagePress={(gage) => {
-            if (gage && router) {
-              router.push({ pathname: ROUTES.GageDetails, params: { id: gage.locationId } });
-            }
-          }}
-        />
-      </Card>
-    </If>
+    <>
+      <If condition={isMobile}>
+        <Card
+          height={300}
+          innerHorizontal={Spacing.tiny}
+          innerVertical={Spacing.tiny}
+          bottom={Spacing.small}>
+          <GageMap
+            gages={gages || []}
+            region={region}
+            onGagePress={(gage) => {
+              if (gage && router) {
+                router.push({ pathname: ROUTES.GageDetails, params: { id: gage.locationId } });
+              }
+            }}
+          />
+        </Card>
+      </If>
+      <RegionSummaryCard />
+    </>
   );
 };
 
 const keyExtractor = (item: Gage) => item?.locationId;
+const renderGageItem = ({ item }: { item: Gage }) =>
+  item?._isStub ? <HiddenGageItem item={item} /> : <GageItem item={item} />;
 const getItemLayout = (data: Gage[], index: number) => ({
   length: ITEM_HEIGHT,
   offset: ITEM_HEIGHT * index,
@@ -176,7 +183,6 @@ const HomeScreen = observer(function HomeScreen() {
 
   const { height } = useWindowDimensions();
 
-  const [hidden, setHidden] = React.useState(isMobile ? true : false);
   const [refreshing, setRefreshing] = React.useState(false);
 
   // Fetch data on mount
@@ -191,10 +197,6 @@ const HomeScreen = observer(function HomeScreen() {
     gagesStore.fetchData();
   }, Timing.fiveMinutes);
 
-  useTimeout(() => {
-    setHidden(false);
-  }, Timing.zero);
-
   const handleOnRefresh = React.useCallback(() => {
     setRefreshing(true);
 
@@ -206,7 +208,7 @@ const HomeScreen = observer(function HomeScreen() {
   }, [gagesStore.fetchData]);
 
   const router = useRouter();
-  const locations = hidden ? [] : getLocationsWithGages();
+  const locations = getLocationsWithGages();
 
   const mapCardHeight = height - HEADER_HEIGHT - Spacing.button;
 
@@ -246,7 +248,7 @@ const HomeScreen = observer(function HomeScreen() {
             initialNumToRender={4}
             keyExtractor={keyExtractor}
             getItemLayout={getItemLayout}
-            renderItem={({ item }) => <GageItem item={item} />}
+            renderItem={renderGageItem}
             ListEmptyComponent={<EmptyComponent />}
             ListHeaderComponent={<HeaderComponent gages={locations} region={regionStore.region} />}
           />

--- a/app/(root)/gage/index.tsx
+++ b/app/(root)/gage/index.tsx
@@ -170,18 +170,7 @@ const HeaderComponent = ({ gages, region }: { gages: Gage[]; region: Region }) =
 const keyExtractor = (item: Gage) => item?.locationId;
 const renderGageItem = ({ item }: { item: Gage }) => {
   if (item?._isStub) {
-    // Pass a plain-JS POJO to HiddenGageItem so React DevTools' commit-phase prop
-    // traversal never sees an MST proxy (which can trip MST 7's "initializing phase"
-    // assertion on lazy empty-array children). See mobx-state-tree#2279 and the comment
-    // on the HiddenStubItem type for the full story.
-    return (
-      <HiddenGageItem
-        item={{
-          locationId: item.locationId,
-          locationName: item.locationInfo?.locationName,
-        }}
-      />
-    );
+    return <HiddenGageItem item={item} />;
   }
   return <GageItem item={item} />;
 };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ module.exports = defineConfig([
       // Warn instead of error on unescaped entities — legacy legal text files
       "react/no-unescaped-entities": "warn",
       curly: "error",
+      "no-nested-ternary": "error",
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "floodzuki",
-  "version": "1.0.25",
+  "version": "1.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "floodzuki",
-      "version": "1.0.25",
+      "version": "1.0.30",
       "hasInstallScript": true,
       "dependencies": {
         "@expo-google-fonts/montserrat": "^0.4.2",

--- a/src/common-ui/components/Card.tsx
+++ b/src/common-ui/components/Card.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { View, ViewStyle, ColorValue, TouchableOpacity } from "react-native";
 import { Colors, ColorTypes } from "@common-ui/constants/colors";
 import { OffsetProps, useOffsetStyles } from "@common-ui/utils/useOffset";
+import { FlexProp, resolveFlexValue } from "@common-ui/utils/flex";
 import { Spacing } from "@common-ui/constants/spacing";
 import { Cell, Row, Separator } from "./Common";
 import { If } from "./Conditional";
@@ -15,7 +16,7 @@ type CardProps = {
   outline?: boolean;
   backgroundColor?: ColorValue;
   noPadding?: boolean;
-  flex?: boolean | number | string;
+  flex?: FlexProp;
 } & OffsetProps;
 
 type CardItemProps = {
@@ -58,9 +59,7 @@ const Base = (props: BaseProps): React.ReactElement => {
   }
 
   if (flex) {
-    const flexValue =
-      typeof flex === "boolean" ? 1 : typeof flex === "string" ? parseFloat(flex) : flex;
-    style.push({ flex: flexValue });
+    style.push({ flex: resolveFlexValue(flex) });
   }
 
   if ((type && type !== "default") || backgroundColor) {

--- a/src/common-ui/components/Common.tsx
+++ b/src/common-ui/components/Common.tsx
@@ -4,6 +4,7 @@ import { ColorValue, View, ViewStyle } from "react-native";
 import { Colors } from "@common-ui/constants/colors";
 import { Spacing } from "@common-ui/constants/spacing";
 import { OffsetProps, useOffsetStyles } from "@common-ui/utils/useOffset";
+import { FlexProp, resolveFlexValue } from "@common-ui/utils/flex";
 import { If } from "./Conditional";
 import { useResponsive } from "@common-ui/utils/responsive";
 
@@ -11,7 +12,7 @@ type RowProps = {
   children?: React.ReactNode;
   wrap?: boolean;
   reverseColumns?: boolean;
-  flex?: boolean | number | string;
+  flex?: FlexProp;
   gap?: number;
   align?: "center" | "space-between" | "space-around" | "space-evenly" | "flex-start" | "flex-end";
   justify?: "center" | "flex-start" | "flex-end" | "stretch" | "baseline";
@@ -20,7 +21,7 @@ type RowProps = {
 
 type CellProps = {
   children?: React.ReactNode;
-  flex?: boolean | number | string;
+  flex?: FlexProp;
   gap?: number;
   wrap?: boolean;
   align?: "center" | "flex-start" | "flex-end" | "stretch" | "baseline";
@@ -84,9 +85,7 @@ export const Row = ({
   }
 
   if (flex) {
-    const flexValue =
-      typeof flex === "boolean" ? 1 : typeof flex === "string" ? parseFloat(flex) : flex;
-    styles.push({ flex: flexValue });
+    styles.push({ flex: resolveFlexValue(flex) });
   }
 
   if (gap) {
@@ -165,9 +164,7 @@ export const Cell = ({
   }
 
   if (flex) {
-    const flexValue =
-      typeof flex === "boolean" ? 1 : typeof flex === "string" ? parseFloat(flex) : flex;
-    styles.push({ flex: flexValue });
+    styles.push({ flex: resolveFlexValue(flex) });
   }
 
   if (gap) {

--- a/src/common-ui/components/Label.tsx
+++ b/src/common-ui/components/Label.tsx
@@ -6,7 +6,7 @@ import { OffsetProps, useOffsetStyles } from "@common-ui/utils/useOffset";
 import { LargeTitle, SmallText, SmallTitle } from "./Text";
 import { useResponsive } from "@common-ui/utils/responsive";
 
-const LARGE_LABEL_COLORS = {
+export const LARGE_LABEL_COLORS = {
   success: {
     backgroundColor: "#e8f4d1",
     textColor: "#9fd140",

--- a/src/common-ui/components/SingleDatePicker.tsx
+++ b/src/common-ui/components/SingleDatePicker.tsx
@@ -242,36 +242,37 @@ const CalendarContent = ({
           {/* Calendar day rows */}
           {rows.map((row, rowIdx) => (
             <Row align="space-around" key={rowIdx} bottom={Spacing.tiny}>
-              {row.map((day, colIdx) => (
-                <Cell flex align="center" key={`${rowIdx}-${colIdx}`}>
-                  {day !== null ? (
-                    <Pressable
-                      disabled={isDisabled(day)}
-                      style={(state) => [
-                        ...cellPressableStyle(state),
-                        isSelected(day)
-                          ? {
-                              backgroundColor: Colors.primary,
-                            }
-                          : {},
-                      ]}
-                      onPress={() => onSelectDay(day, viewYear, viewMonth)}>
-                      <RegularText
-                        text={String(day)}
-                        color={
+              {row.map((day, colIdx) => {
+                let dayColor: string | undefined;
+                if (day !== null) {
+                  if (isSelected(day)) {
+                    dayColor = Colors.white;
+                  } else if (isDisabled(day)) {
+                    dayColor = Colors.darkGrey;
+                  }
+                }
+                return (
+                  <Cell flex align="center" key={`${rowIdx}-${colIdx}`}>
+                    {day !== null ? (
+                      <Pressable
+                        disabled={isDisabled(day)}
+                        style={(state) => [
+                          ...cellPressableStyle(state),
                           isSelected(day)
-                            ? Colors.white
-                            : isDisabled(day)
-                            ? Colors.darkGrey
-                            : undefined
-                        }
-                      />
-                    </Pressable>
-                  ) : (
-                    <Cell />
-                  )}
-                </Cell>
-              ))}
+                            ? {
+                                backgroundColor: Colors.primary,
+                              }
+                            : {},
+                        ]}
+                        onPress={() => onSelectDay(day, viewYear, viewMonth)}>
+                        <RegularText text={String(day)} color={dayColor} />
+                      </Pressable>
+                    ) : (
+                      <Cell />
+                    )}
+                  </Cell>
+                );
+              })}
             </Row>
           ))}
         </Cell>
@@ -329,12 +330,14 @@ export const SingleDatePicker = ({
 
     const { pageX, pageY } = pickerLayout.current;
     const offsetLeft = pageX - Spacing.medium;
-    const leftOffset =
-      width < 768
-        ? (width - PICKER_WIDTH) / 2
-        : offsetLeft + PICKER_WIDTH > width
-        ? width - PICKER_WIDTH - Spacing.small
-        : offsetLeft;
+    let leftOffset: number;
+    if (width < 768) {
+      leftOffset = (width - PICKER_WIDTH) / 2;
+    } else if (offsetLeft + PICKER_WIDTH > width) {
+      leftOffset = width - PICKER_WIDTH - Spacing.small;
+    } else {
+      leftOffset = offsetLeft;
+    }
 
     setIsOpen(true);
     datePickerContext.showPicker(

--- a/src/common-ui/utils/flex.ts
+++ b/src/common-ui/utils/flex.ts
@@ -1,0 +1,11 @@
+export type FlexProp = boolean | number | string;
+
+export function resolveFlexValue(flex: FlexProp): number {
+  if (typeof flex === "boolean") {
+    return 1;
+  }
+  if (typeof flex === "string") {
+    return parseFloat(flex);
+  }
+  return flex;
+}

--- a/src/components/GageDetailsChart.tsx
+++ b/src/components/GageDetailsChart.tsx
@@ -578,7 +578,18 @@ export const GageDetailsChart = observer(function GageDetailsChart(props: GageDe
         <Cell height={320} flex>
           <ActivityIndicator animating />
         </Cell>
-        <Charts options={chartOptions} />
+        <View style={$chartContainer}>
+          <Charts options={chartOptions} />
+          {!gage?.hasData && (
+            <View pointerEvents="none" style={$noDataOverlay}>
+              <View style={$noDataPill}>
+                <RegularText color={Colors.lightDark}>
+                  {t("gageDetailsChart.noDataInRange")}
+                </RegularText>
+              </View>
+            </View>
+          )}
+        </View>
       </Ternary>
       <CardFooter horizontal={-Spacing.extraSmall}>
         <Row align="space-between">
@@ -628,6 +639,27 @@ const $pickerSelectorStyle: ViewStyle = {
   flexDirection: "row",
   justifyContent: "space-between",
   alignItems: "center",
+};
+
+const $chartContainer: ViewStyle = {
+  position: "relative",
+};
+
+const $noDataOverlay: ViewStyle = {
+  position: "absolute",
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  alignItems: "center",
+  justifyContent: "center",
+};
+
+const $noDataPill: ViewStyle = {
+  backgroundColor: Colors.softYellow,
+  paddingHorizontal: Spacing.medium,
+  paddingVertical: Spacing.small,
+  borderRadius: Spacing.tiny,
 };
 
 const $bottomSheetStyle: ViewStyle = {

--- a/src/components/HiddenGageItem.tsx
+++ b/src/components/HiddenGageItem.tsx
@@ -56,7 +56,7 @@ const HiddenGageItem = function HiddenGageItem({ item }: HiddenGageItemProps) {
               </Cell>
             </Row>
             <Row wrap align="space-between" top={Spacing.small}>
-              <LargeLabel type="offline" text={t("regionSummary.offlineGauge")} />
+              <LargeLabel type="offline" text={t("statuses.Offline")} />
               <SmallerText muted>{t("regionSummary.noRecentData")}</SmallerText>
             </Row>
           </Cell>

--- a/src/components/HiddenGageItem.tsx
+++ b/src/components/HiddenGageItem.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { TouchableOpacity } from "react-native";
+import { Link } from "expo-router";
+import { observer } from "mobx-react-lite";
+
+import { Card } from "@common-ui/components/Card";
+import { Cell, Row } from "@common-ui/components/Common";
+import { SmallerText, SmallTitle } from "@common-ui/components/Text";
+import { Label, LargeLabel } from "@common-ui/components/Label";
+import { Colors } from "@common-ui/constants/colors";
+import { Spacing } from "@common-ui/constants/spacing";
+import { useLocale } from "@common-ui/contexts/LocaleContext";
+import { Gage } from "@models/Gage";
+import { ROUTES } from "app/_layout";
+
+const ITEM_HEIGHT = 200;
+
+interface HiddenGageItemProps {
+  item: Gage;
+}
+
+const HiddenGageItem = observer(function HiddenGageItem({ item }: HiddenGageItemProps) {
+  const { t } = useLocale();
+
+  return (
+    <Card
+      height={ITEM_HEIGHT}
+      bottom={Spacing.medium}
+      innerHorizontal={0}
+      innerVertical={0}
+      backgroundColor={Colors.lightGrey}>
+      <Link href={{ pathname: ROUTES.GageDetails, params: { id: item?.locationId } }} asChild>
+        <TouchableOpacity style={{ flex: 1 }}>
+          <Cell
+            flex
+            justify="center"
+            innerHorizontal={Spacing.large}
+            innerVertical={Spacing.medium}>
+            <Row align="space-between" justify="flex-start">
+              <Cell flex>
+                <SmallTitle color={Colors.midGrey}>{item?.locationInfo?.locationName}</SmallTitle>
+              </Cell>
+              <Cell>
+                <Label text={item?.locationId} />
+              </Cell>
+            </Row>
+            <Row wrap align="space-between" top={Spacing.medium}>
+              <LargeLabel type="offline" text={t("regionSummary.offlineGauge")} />
+              <SmallerText color={Colors.midGrey}>{t("regionSummary.noRecentData")}</SmallerText>
+            </Row>
+          </Cell>
+        </TouchableOpacity>
+      </Link>
+    </Card>
+  );
+});
+
+export default HiddenGageItem;

--- a/src/components/HiddenGageItem.tsx
+++ b/src/components/HiddenGageItem.tsx
@@ -57,7 +57,7 @@ const HiddenGageItem = function HiddenGageItem({ item }: HiddenGageItemProps) {
             </Row>
             <Row wrap align="space-between" top={Spacing.small}>
               <LargeLabel type="offline" text={t("regionSummary.offlineGauge")} />
-              <SmallerText color={Colors.midGrey}>{t("regionSummary.noRecentData")}</SmallerText>
+              <SmallerText muted>{t("regionSummary.noRecentData")}</SmallerText>
             </Row>
           </Cell>
         </TouchableOpacity>

--- a/src/components/HiddenGageItem.tsx
+++ b/src/components/HiddenGageItem.tsx
@@ -10,25 +10,13 @@ import { Colors } from "@common-ui/constants/colors";
 import { Spacing } from "@common-ui/constants/spacing";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
 import { useResponsive } from "@common-ui/utils/responsive";
+import { Gage } from "@models/Gage";
 import { ROUTES } from "app/_layout";
 
 const ITEM_HEIGHT = 120;
 
-/**
- * Plain-JS shape passed as `item`. We deliberately do NOT take an MST `Gage` instance
- * here: MST 7 has an unfixed bug (github.com/mobxjs/mobx-state-tree#2279) where React
- * DevTools' deep prop traversal in the commit phase trips MST's "initializing phase"
- * assertion when it walks empty `types.array(...)` children. Passing a plain object
- * means DevTools only ever sees plain JS — no MST proxy, no lazy materialization.
- * The caller in HomeScreen extracts the few fields we need from the MST stub.
- */
-interface HiddenStubItem {
-  locationId: string;
-  locationName?: string;
-}
-
 interface HiddenGageItemProps {
-  item: HiddenStubItem;
+  item: Gage;
 }
 
 const HiddenGageItem = function HiddenGageItem({ item }: HiddenGageItemProps) {
@@ -49,7 +37,7 @@ const HiddenGageItem = function HiddenGageItem({ item }: HiddenGageItemProps) {
             innerHorizontal={horizontalPadding + Spacing.small}>
             <Row align="space-between" justify="flex-start">
               <Cell flex>
-                <Title color={Colors.lightDark}>{item.locationName}</Title>
+                <Title color={Colors.lightDark}>{item.locationInfo?.locationName}</Title>
               </Cell>
               <Cell>
                 <Label text={item.locationId} />

--- a/src/components/HiddenGageItem.tsx
+++ b/src/components/HiddenGageItem.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { TouchableOpacity } from "react-native";
 import { Link } from "expo-router";
-import { observer } from "mobx-react-lite";
 
 import { Card } from "@common-ui/components/Card";
 import { Cell, Row } from "@common-ui/components/Common";
@@ -10,16 +9,28 @@ import { Label, LargeLabel } from "@common-ui/components/Label";
 import { Colors } from "@common-ui/constants/colors";
 import { Spacing } from "@common-ui/constants/spacing";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import { Gage } from "@models/Gage";
 import { ROUTES } from "app/_layout";
 
 const ITEM_HEIGHT = 200;
 
-interface HiddenGageItemProps {
-  item: Gage;
+/**
+ * Plain-JS shape passed as `item`. We deliberately do NOT take an MST `Gage` instance
+ * here: MST 7 has an unfixed bug (github.com/mobxjs/mobx-state-tree#2279) where React
+ * DevTools' deep prop traversal in the commit phase trips MST's "initializing phase"
+ * assertion when it walks empty `types.array(...)` children. Passing a plain object
+ * means DevTools only ever sees plain JS — no MST proxy, no lazy materialization.
+ * The caller in HomeScreen extracts the few fields we need from the MST stub.
+ */
+interface HiddenStubItem {
+  locationId: string;
+  locationName?: string;
 }
 
-const HiddenGageItem = observer(function HiddenGageItem({ item }: HiddenGageItemProps) {
+interface HiddenGageItemProps {
+  item: HiddenStubItem;
+}
+
+const HiddenGageItem = function HiddenGageItem({ item }: HiddenGageItemProps) {
   const { t } = useLocale();
 
   return (
@@ -29,7 +40,7 @@ const HiddenGageItem = observer(function HiddenGageItem({ item }: HiddenGageItem
       innerHorizontal={0}
       innerVertical={0}
       backgroundColor={Colors.lightGrey}>
-      <Link href={{ pathname: ROUTES.GageDetails, params: { id: item?.locationId } }} asChild>
+      <Link href={{ pathname: ROUTES.GageDetails, params: { id: item.locationId } }} asChild>
         <TouchableOpacity style={{ flex: 1 }}>
           <Cell
             flex
@@ -38,10 +49,10 @@ const HiddenGageItem = observer(function HiddenGageItem({ item }: HiddenGageItem
             innerVertical={Spacing.medium}>
             <Row align="space-between" justify="flex-start">
               <Cell flex>
-                <SmallTitle color={Colors.midGrey}>{item?.locationInfo?.locationName}</SmallTitle>
+                <SmallTitle color={Colors.midGrey}>{item.locationName}</SmallTitle>
               </Cell>
               <Cell>
-                <Label text={item?.locationId} />
+                <Label text={item.locationId} />
               </Cell>
             </Row>
             <Row wrap align="space-between" top={Spacing.medium}>
@@ -53,6 +64,6 @@ const HiddenGageItem = observer(function HiddenGageItem({ item }: HiddenGageItem
       </Link>
     </Card>
   );
-});
+};
 
 export default HiddenGageItem;

--- a/src/components/HiddenGageItem.tsx
+++ b/src/components/HiddenGageItem.tsx
@@ -4,14 +4,15 @@ import { Link } from "expo-router";
 
 import { Card } from "@common-ui/components/Card";
 import { Cell, Row } from "@common-ui/components/Common";
-import { SmallerText, SmallTitle } from "@common-ui/components/Text";
+import { SmallerText, SmallTitle, LargerTitle } from "@common-ui/components/Text";
 import { Label, LargeLabel } from "@common-ui/components/Label";
 import { Colors } from "@common-ui/constants/colors";
 import { Spacing } from "@common-ui/constants/spacing";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
+import { useResponsive } from "@common-ui/utils/responsive";
 import { ROUTES } from "app/_layout";
 
-const ITEM_HEIGHT = 200;
+const ITEM_HEIGHT = 120;
 
 /**
  * Plain-JS shape passed as `item`. We deliberately do NOT take an MST `Gage` instance
@@ -32,30 +33,29 @@ interface HiddenGageItemProps {
 
 const HiddenGageItem = function HiddenGageItem({ item }: HiddenGageItemProps) {
   const { t } = useLocale();
+  const { isMobile } = useResponsive();
+
+  const Title = isMobile ? SmallTitle : LargerTitle;
+  const horizontalPadding = isMobile ? Spacing.medium : Spacing.large;
 
   return (
-    <Card
-      height={ITEM_HEIGHT}
-      bottom={Spacing.medium}
-      innerHorizontal={0}
-      innerVertical={0}
-      backgroundColor={Colors.lightGrey}>
+    <Card height={ITEM_HEIGHT} bottom={Spacing.medium} innerHorizontal={0} innerVertical={0}>
       <Link href={{ pathname: ROUTES.GageDetails, params: { id: item.locationId } }} asChild>
         <TouchableOpacity style={{ flex: 1 }}>
           <Cell
             flex
             justify="center"
-            innerHorizontal={Spacing.large}
-            innerVertical={Spacing.medium}>
+            horizontal={0}
+            innerHorizontal={horizontalPadding + Spacing.small}>
             <Row align="space-between" justify="flex-start">
               <Cell flex>
-                <SmallTitle color={Colors.midGrey}>{item.locationName}</SmallTitle>
+                <Title color={Colors.lightDark}>{item.locationName}</Title>
               </Cell>
               <Cell>
                 <Label text={item.locationId} />
               </Cell>
             </Row>
-            <Row wrap align="space-between" top={Spacing.medium}>
+            <Row wrap align="space-between" top={Spacing.small}>
               <LargeLabel type="offline" text={t("regionSummary.offlineGauge")} />
               <SmallerText color={Colors.midGrey}>{t("regionSummary.noRecentData")}</SmallerText>
             </Row>

--- a/src/components/RegionSummaryCard.tsx
+++ b/src/components/RegionSummaryCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Switch, View } from "react-native";
+import { Switch, TouchableOpacity } from "react-native";
 import { Link } from "expo-router";
 import { observer } from "mobx-react-lite";
 
@@ -50,7 +50,8 @@ const RegionSummaryCard = observer(function RegionSummaryCard() {
 
   const ForecastPill = (
     <Link href={ROUTES.Forecast} asChild>
-      <View
+      <TouchableOpacity
+        activeOpacity={0.7}
         style={{
           marginTop: Spacing.small,
           borderLeftWidth: 3,
@@ -64,7 +65,7 @@ const RegionSummaryCard = observer(function RegionSummaryCard() {
           borderRadius={4}>
           <SmallerText color={forecastColor}>{forecastCopy}</SmallerText>
         </Cell>
-      </View>
+      </TouchableOpacity>
     </Link>
   );
 

--- a/src/components/RegionSummaryCard.tsx
+++ b/src/components/RegionSummaryCard.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { Switch } from "react-native";
+import { Link } from "expo-router";
+import { observer } from "mobx-react-lite";
+
+import { Card } from "@common-ui/components/Card";
+import { Cell, Row, RowOrCell } from "@common-ui/components/Common";
+import { LabelText, SmallerText, SmallTitle } from "@common-ui/components/Text";
+import { Colors } from "@common-ui/constants/colors";
+import { Spacing } from "@common-ui/constants/spacing";
+import { useLocale } from "@common-ui/contexts/LocaleContext";
+import { useResponsive } from "@common-ui/utils/responsive";
+import { useStores } from "@models/helpers/useStores";
+import { ROUTES } from "app/_layout";
+
+const RegionSummaryCard = observer(function RegionSummaryCard() {
+  const { t } = useLocale();
+  const { isMobile } = useResponsive();
+  const { showHiddenOffline, setShowHiddenOffline, getBucketCounts, forecastsStore } = useStores();
+
+  const counts = getBucketCounts();
+
+  const floodingText =
+    counts.flooding > 0 ? t("regionSummary.flooding", { count: counts.flooding }) : null;
+  const nearFloodingText =
+    counts.nearFlooding > 0
+      ? t("regionSummary.nearFlooding", { count: counts.nearFlooding })
+      : null;
+  const isCalm = !floodingText && !nearFloodingText;
+  const statusColor =
+    counts.flooding > 0 ? Colors.danger : counts.nearFlooding > 0 ? Colors.warning : Colors.success;
+
+  const severity = forecastsStore.severity as "none" | "near" | "flood";
+  const forecastCopy =
+    severity === "flood"
+      ? t("regionSummary.floodingPredicted")
+      : severity === "near"
+      ? t("regionSummary.nearFloodPredicted")
+      : t("regionSummary.noFloodingPredicted");
+  const forecastColor =
+    severity === "flood" ? Colors.danger : severity === "near" ? Colors.warning : Colors.success;
+  const forecastBg =
+    severity === "flood"
+      ? Colors.softRed
+      : severity === "near"
+      ? Colors.softYellow
+      : Colors.softGreen;
+
+  const ForecastPill = (
+    <Link href={ROUTES.Forecast} asChild>
+      <Cell
+        bgColor={forecastBg}
+        innerHorizontal={Spacing.small}
+        innerVertical={Spacing.tiny}
+        top={Spacing.small}
+        style={{ borderLeftWidth: 3, borderLeftColor: forecastColor, borderRadius: 4 }}>
+        <SmallerText color={forecastColor}>{forecastCopy}</SmallerText>
+      </Cell>
+    </Link>
+  );
+
+  return (
+    <Card bottom={Spacing.medium} innerHorizontal={Spacing.medium} innerVertical={Spacing.medium}>
+      <RowOrCell flex justify="flex-start" align="space-between">
+        <Cell flex>
+          {isCalm ? (
+            <SmallTitle color={statusColor}>{t("regionSummary.allNormal")}</SmallTitle>
+          ) : (
+            <>
+              {floodingText ? <SmallTitle color={statusColor}>{floodingText}</SmallTitle> : null}
+              {nearFloodingText ? (
+                <SmallTitle color={statusColor}>{nearFloodingText}</SmallTitle>
+              ) : null}
+            </>
+          )}
+          {ForecastPill}
+        </Cell>
+        <Cell
+          left={isMobile ? 0 : Spacing.medium}
+          top={isMobile ? Spacing.medium : 0}
+          align={isMobile ? "flex-start" : "flex-end"}>
+          <SmallerText>
+            <SmallerText color={Colors.lightDark}>{counts.active}</SmallerText>{" "}
+            {t("regionSummary.active")}
+          </SmallerText>
+          <SmallerText>
+            <SmallerText color={Colors.lightDark}>{counts.visibleOffline}</SmallerText>{" "}
+            {t("regionSummary.offline")}
+          </SmallerText>
+          <SmallerText>
+            <SmallerText color={Colors.lightDark}>{counts.hidden}</SmallerText>{" "}
+            {t("regionSummary.hidden")}
+          </SmallerText>
+          <Row top={Spacing.tiny} align="flex-end">
+            <LabelText>{t("regionSummary.showHidden")}</LabelText>
+            <Cell left={Spacing.tiny}>
+              <Switch
+                testID="region-summary-toggle"
+                value={showHiddenOffline}
+                disabled={counts.hidden === 0}
+                onValueChange={setShowHiddenOffline}
+              />
+            </Cell>
+          </Row>
+        </Cell>
+      </RowOrCell>
+    </Card>
+  );
+});
+
+export default RegionSummaryCard;

--- a/src/components/RegionSummaryCard.tsx
+++ b/src/components/RegionSummaryCard.tsx
@@ -3,20 +3,17 @@ import { Switch, TouchableOpacity } from "react-native";
 import { Link } from "expo-router";
 import { observer } from "mobx-react-lite";
 
-import { Card } from "@common-ui/components/Card";
-import { Cell, Row, RowOrCell } from "@common-ui/components/Common";
+import { Cell, Row } from "@common-ui/components/Common";
 import { LARGE_LABEL_COLORS } from "@common-ui/components/Label";
 import { SmallerText, SmallTitle } from "@common-ui/components/Text";
 import { Colors } from "@common-ui/constants/colors";
 import { Spacing } from "@common-ui/constants/spacing";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import { useResponsive } from "@common-ui/utils/responsive";
 import { useStores } from "@models/helpers/useStores";
 import { ROUTES } from "app/_layout";
 
 const RegionSummaryCard = observer(function RegionSummaryCard() {
   const { t } = useLocale();
-  const { isMobile } = useResponsive();
   const { showHiddenOffline, setShowHiddenOffline, getBucketCounts, forecastsStore } = useStores();
 
   const counts = getBucketCounts();
@@ -51,7 +48,6 @@ const RegionSummaryCard = observer(function RegionSummaryCard() {
       <TouchableOpacity
         activeOpacity={0.7}
         style={{
-          marginTop: isMobile ? Spacing.small : 0,
           borderLeftWidth: 3,
           borderLeftColor: forecastColor,
           borderRadius: 4,
@@ -72,14 +68,14 @@ const RegionSummaryCard = observer(function RegionSummaryCard() {
       bottom={Spacing.extraSmall}
       innerHorizontal={Spacing.medium}
       innerVertical={Spacing.extraSmall}>
-      <RowOrCell justify="center" align="space-between">
+      <Row justify="center" align="space-between">
         <Cell flex>
           <SmallTitle color={statusColor}>{statusText}</SmallTitle>
         </Cell>
-        <Cell left={isMobile ? 0 : Spacing.medium} align={isMobile ? "flex-start" : "flex-end"}>
+        <Cell left={Spacing.medium} align="flex-end">
           {ForecastPill}
         </Cell>
-      </RowOrCell>
+      </Row>
       <Row top={Spacing.medium} align="space-between" justify="center" wrap>
         <Row>
           <SmallerText>
@@ -90,31 +86,36 @@ const RegionSummaryCard = observer(function RegionSummaryCard() {
               {counts.visibleOffline + counts.hidden}
             </SmallerText>{" "}
             {t("regionSummary.offline")}
-            {" ("}
-            <SmallerText color={Colors.lightDark}>{counts.hidden}</SmallerText>{" "}
-            {t("regionSummary.hidden")}
-            {")"}
+            {counts.hidden > 0 && (
+              <>
+                {" ("}
+                <SmallerText color={Colors.lightDark}>{counts.hidden}</SmallerText>{" "}
+                {t("regionSummary.hidden")}
+                {")"}
+              </>
+            )}
           </SmallerText>
         </Row>
-        <Row>
-          <SmallerText>{t("regionSummary.showHidden")}</SmallerText>
-          <Cell left={Spacing.tiny}>
-            <Switch
-              testID="region-summary-toggle"
-              value={showHiddenOffline}
-              disabled={counts.hidden === 0}
-              onValueChange={setShowHiddenOffline}
-              trackColor={{ false: Colors.lightGrey, true: Colors.primary }}
-              thumbColor={Colors.white}
-              ios_backgroundColor={Colors.lightGrey}
-              // react-native-web extends Switch with activeThumbColor (the on-state
-              // thumb color on web); the prop isn't in react-native's SwitchProps so
-              // TS rejects it on native typings.
-              // @ts-expect-error — web-only prop, see https://necolas.github.io/react-native-web/docs/switch/
-              activeThumbColor={Colors.white}
-            />
-          </Cell>
-        </Row>
+        {counts.hidden > 0 && (
+          <Row>
+            <SmallerText>{t("regionSummary.showHidden")}</SmallerText>
+            <Cell left={Spacing.tiny}>
+              <Switch
+                testID="region-summary-toggle"
+                value={showHiddenOffline}
+                onValueChange={setShowHiddenOffline}
+                trackColor={{ false: Colors.lightGrey, true: Colors.primary }}
+                thumbColor={Colors.white}
+                ios_backgroundColor={Colors.lightGrey}
+                // react-native-web extends Switch with activeThumbColor (the on-state
+                // thumb color on web); the prop isn't in react-native's SwitchProps so
+                // TS rejects it on native typings.
+                // @ts-expect-error — web-only prop, see https://necolas.github.io/react-native-web/docs/switch/
+                activeThumbColor={Colors.white}
+              />
+            </Cell>
+          </Row>
+        )}
       </Row>
     </Cell>
   );

--- a/src/components/RegionSummaryCard.tsx
+++ b/src/components/RegionSummaryCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Switch } from "react-native";
+import { Switch, View } from "react-native";
 import { Link } from "expo-router";
 import { observer } from "mobx-react-lite";
 
@@ -50,14 +50,21 @@ const RegionSummaryCard = observer(function RegionSummaryCard() {
 
   const ForecastPill = (
     <Link href={ROUTES.Forecast} asChild>
-      <Cell
-        bgColor={forecastBg}
-        innerHorizontal={Spacing.small}
-        innerVertical={Spacing.tiny}
-        top={Spacing.small}
-        style={{ borderLeftWidth: 3, borderLeftColor: forecastColor, borderRadius: 4 }}>
-        <SmallerText color={forecastColor}>{forecastCopy}</SmallerText>
-      </Cell>
+      <View
+        style={{
+          marginTop: Spacing.small,
+          borderLeftWidth: 3,
+          borderLeftColor: forecastColor,
+          borderRadius: 4,
+        }}>
+        <Cell
+          bgColor={forecastBg}
+          innerHorizontal={Spacing.small}
+          innerVertical={Spacing.tiny}
+          borderRadius={4}>
+          <SmallerText color={forecastColor}>{forecastCopy}</SmallerText>
+        </Cell>
+      </View>
     </Link>
   );
 

--- a/src/components/RegionSummaryCard.tsx
+++ b/src/components/RegionSummaryCard.tsx
@@ -6,7 +6,7 @@ import { observer } from "mobx-react-lite";
 import { Card } from "@common-ui/components/Card";
 import { Cell, Row, RowOrCell } from "@common-ui/components/Common";
 import { LARGE_LABEL_COLORS } from "@common-ui/components/Label";
-import { LabelText, SmallerText, SmallTitle } from "@common-ui/components/Text";
+import { SmallerText, SmallTitle } from "@common-ui/components/Text";
 import { Colors } from "@common-ui/constants/colors";
 import { Spacing } from "@common-ui/constants/spacing";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
@@ -51,7 +51,7 @@ const RegionSummaryCard = observer(function RegionSummaryCard() {
       <TouchableOpacity
         activeOpacity={0.7}
         style={{
-          marginTop: Spacing.small,
+          marginTop: isMobile ? Spacing.small : 0,
           borderLeftWidth: 3,
           borderLeftColor: forecastColor,
           borderRadius: 4,
@@ -68,52 +68,55 @@ const RegionSummaryCard = observer(function RegionSummaryCard() {
   );
 
   return (
-    <Card bottom={Spacing.medium} innerHorizontal={Spacing.medium} innerVertical={Spacing.medium}>
-      <RowOrCell flex justify="flex-start" align="space-between">
+    <Cell
+      bottom={Spacing.extraSmall}
+      innerHorizontal={Spacing.medium}
+      innerVertical={Spacing.extraSmall}>
+      <RowOrCell justify="center" align="space-between">
         <Cell flex>
           <SmallTitle color={statusColor}>{statusText}</SmallTitle>
+        </Cell>
+        <Cell left={isMobile ? 0 : Spacing.medium} align={isMobile ? "flex-start" : "flex-end"}>
           {ForecastPill}
         </Cell>
-        <Cell
-          left={isMobile ? 0 : Spacing.medium}
-          top={isMobile ? Spacing.medium : 0}
-          align={isMobile ? "flex-start" : "flex-end"}>
+      </RowOrCell>
+      <Row top={Spacing.medium} align="space-between" justify="center" wrap>
+        <Row>
           <SmallerText>
             <SmallerText color={Colors.lightDark}>{counts.active}</SmallerText>{" "}
             {t("regionSummary.active")}
-          </SmallerText>
-          <SmallerText>
+            {", "}
             <SmallerText color={Colors.lightDark}>
               {counts.visibleOffline + counts.hidden}
             </SmallerText>{" "}
             {t("regionSummary.offline")}
-          </SmallerText>
-          <SmallerText>
+            {" ("}
             <SmallerText color={Colors.lightDark}>{counts.hidden}</SmallerText>{" "}
             {t("regionSummary.hidden")}
+            {")"}
           </SmallerText>
-          <Row top={Spacing.tiny} align="flex-end">
-            <SmallerText>{t("regionSummary.showHidden")}</SmallerText>
-            <Cell left={Spacing.tiny}>
-              <Switch
-                testID="region-summary-toggle"
-                value={showHiddenOffline}
-                disabled={counts.hidden === 0}
-                onValueChange={setShowHiddenOffline}
-                trackColor={{ false: Colors.lightGrey, true: Colors.primary }}
-                thumbColor={Colors.white}
-                ios_backgroundColor={Colors.lightGrey}
-                // react-native-web extends Switch with activeThumbColor (the on-state
-                // thumb color on web); the prop isn't in react-native's SwitchProps so
-                // TS rejects it on native typings.
-                // @ts-expect-error — web-only prop, see https://necolas.github.io/react-native-web/docs/switch/
-                activeThumbColor={Colors.white}
-              />
-            </Cell>
-          </Row>
-        </Cell>
-      </RowOrCell>
-    </Card>
+        </Row>
+        <Row>
+          <SmallerText>{t("regionSummary.showHidden")}</SmallerText>
+          <Cell left={Spacing.tiny}>
+            <Switch
+              testID="region-summary-toggle"
+              value={showHiddenOffline}
+              disabled={counts.hidden === 0}
+              onValueChange={setShowHiddenOffline}
+              trackColor={{ false: Colors.lightGrey, true: Colors.primary }}
+              thumbColor={Colors.white}
+              ios_backgroundColor={Colors.lightGrey}
+              // react-native-web extends Switch with activeThumbColor (the on-state
+              // thumb color on web); the prop isn't in react-native's SwitchProps so
+              // TS rejects it on native typings.
+              // @ts-expect-error — web-only prop, see https://necolas.github.io/react-native-web/docs/switch/
+              activeThumbColor={Colors.white}
+            />
+          </Cell>
+        </Row>
+      </Row>
+    </Cell>
   );
 });
 

--- a/src/components/RegionSummaryCard.tsx
+++ b/src/components/RegionSummaryCard.tsx
@@ -10,6 +10,7 @@ import { Colors } from "@common-ui/constants/colors";
 import { Spacing } from "@common-ui/constants/spacing";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
 import { useStores } from "@models/helpers/useStores";
+import { ForecastSeverity } from "@models/helpers/regionSummary";
 import { ROUTES } from "app/_layout";
 
 const RegionSummaryCard = observer(function RegionSummaryCard() {
@@ -31,13 +32,17 @@ const RegionSummaryCard = observer(function RegionSummaryCard() {
     counts.flooding > 0 ? "danger" : counts.nearFlooding > 0 ? "warning" : "success";
   const statusColor = LARGE_LABEL_COLORS[statusLabelType].textColor;
 
-  const severity = forecastsStore.severity as "none" | "near" | "flood";
+  const severity = forecastsStore.severity as ForecastSeverity;
   const forecastLabelType =
-    severity === "flood" ? "danger" : severity === "near" ? "warning" : "success";
+    severity === ForecastSeverity.Flood
+      ? "danger"
+      : severity === ForecastSeverity.Near
+      ? "warning"
+      : "success";
   const forecastCopy =
-    severity === "flood"
+    severity === ForecastSeverity.Flood
       ? t("regionSummary.floodingPredicted")
-      : severity === "near"
+      : severity === ForecastSeverity.Near
       ? t("regionSummary.nearFloodPredicted")
       : t("regionSummary.noFloodingPredicted");
   const forecastColor = LARGE_LABEL_COLORS[forecastLabelType].textColor;

--- a/src/components/RegionSummaryCard.tsx
+++ b/src/components/RegionSummaryCard.tsx
@@ -85,7 +85,9 @@ const RegionSummaryCard = observer(function RegionSummaryCard() {
             {t("regionSummary.active")}
           </SmallerText>
           <SmallerText>
-            <SmallerText color={Colors.lightDark}>{counts.visibleOffline}</SmallerText>{" "}
+            <SmallerText color={Colors.lightDark}>
+              {counts.visibleOffline + counts.hidden}
+            </SmallerText>{" "}
             {t("regionSummary.offline")}
           </SmallerText>
           <SmallerText>

--- a/src/components/RegionSummaryCard.tsx
+++ b/src/components/RegionSummaryCard.tsx
@@ -20,13 +20,15 @@ const RegionSummaryCard = observer(function RegionSummaryCard() {
 
   const counts = getBucketCounts();
 
-  const floodingText =
-    counts.flooding > 0 ? t("regionSummary.flooding", { count: counts.flooding }) : null;
-  const nearFloodingText =
-    counts.nearFlooding > 0
-      ? t("regionSummary.nearFlooding", { count: counts.nearFlooding })
-      : null;
-  const isCalm = !floodingText && !nearFloodingText;
+  const statusParts: string[] = [];
+  if (counts.flooding > 0) {
+    statusParts.push(t("regionSummary.flooding", { count: counts.flooding }));
+  }
+  if (counts.nearFlooding > 0) {
+    statusParts.push(t("regionSummary.nearFlooding", { count: counts.nearFlooding }));
+  }
+  const statusText =
+    statusParts.length === 0 ? t("regionSummary.allNormal") : statusParts.join(" · ");
   const statusColor =
     counts.flooding > 0 ? Colors.danger : counts.nearFlooding > 0 ? Colors.warning : Colors.success;
 
@@ -63,16 +65,7 @@ const RegionSummaryCard = observer(function RegionSummaryCard() {
     <Card bottom={Spacing.medium} innerHorizontal={Spacing.medium} innerVertical={Spacing.medium}>
       <RowOrCell flex justify="flex-start" align="space-between">
         <Cell flex>
-          {isCalm ? (
-            <SmallTitle color={statusColor}>{t("regionSummary.allNormal")}</SmallTitle>
-          ) : (
-            <>
-              {floodingText ? <SmallTitle color={statusColor}>{floodingText}</SmallTitle> : null}
-              {nearFloodingText ? (
-                <SmallTitle color={statusColor}>{nearFloodingText}</SmallTitle>
-              ) : null}
-            </>
-          )}
+          <SmallTitle color={statusColor}>{statusText}</SmallTitle>
           {ForecastPill}
         </Cell>
         <Cell

--- a/src/components/RegionSummaryCard.tsx
+++ b/src/components/RegionSummaryCard.tsx
@@ -5,6 +5,7 @@ import { observer } from "mobx-react-lite";
 
 import { Card } from "@common-ui/components/Card";
 import { Cell, Row, RowOrCell } from "@common-ui/components/Common";
+import { LARGE_LABEL_COLORS } from "@common-ui/components/Label";
 import { LabelText, SmallerText, SmallTitle } from "@common-ui/components/Text";
 import { Colors } from "@common-ui/constants/colors";
 import { Spacing } from "@common-ui/constants/spacing";
@@ -29,24 +30,21 @@ const RegionSummaryCard = observer(function RegionSummaryCard() {
   }
   const statusText =
     statusParts.length === 0 ? t("regionSummary.allNormal") : statusParts.join(" · ");
-  const statusColor =
-    counts.flooding > 0 ? Colors.danger : counts.nearFlooding > 0 ? Colors.warning : Colors.success;
+  const statusLabelType =
+    counts.flooding > 0 ? "danger" : counts.nearFlooding > 0 ? "warning" : "success";
+  const statusColor = LARGE_LABEL_COLORS[statusLabelType].textColor;
 
   const severity = forecastsStore.severity as "none" | "near" | "flood";
+  const forecastLabelType =
+    severity === "flood" ? "danger" : severity === "near" ? "warning" : "success";
   const forecastCopy =
     severity === "flood"
       ? t("regionSummary.floodingPredicted")
       : severity === "near"
       ? t("regionSummary.nearFloodPredicted")
       : t("regionSummary.noFloodingPredicted");
-  const forecastColor =
-    severity === "flood" ? Colors.danger : severity === "near" ? Colors.warning : Colors.success;
-  const forecastBg =
-    severity === "flood"
-      ? Colors.softRed
-      : severity === "near"
-      ? Colors.softYellow
-      : Colors.softGreen;
+  const forecastColor = LARGE_LABEL_COLORS[forecastLabelType].textColor;
+  const forecastBg = LARGE_LABEL_COLORS[forecastLabelType].backgroundColor;
 
   const ForecastPill = (
     <Link href={ROUTES.Forecast} asChild>
@@ -95,13 +93,21 @@ const RegionSummaryCard = observer(function RegionSummaryCard() {
             {t("regionSummary.hidden")}
           </SmallerText>
           <Row top={Spacing.tiny} align="flex-end">
-            <LabelText>{t("regionSummary.showHidden")}</LabelText>
+            <SmallerText>{t("regionSummary.showHidden")}</SmallerText>
             <Cell left={Spacing.tiny}>
               <Switch
                 testID="region-summary-toggle"
                 value={showHiddenOffline}
                 disabled={counts.hidden === 0}
                 onValueChange={setShowHiddenOffline}
+                trackColor={{ false: Colors.lightGrey, true: Colors.primary }}
+                thumbColor={Colors.white}
+                ios_backgroundColor={Colors.lightGrey}
+                // react-native-web extends Switch with activeThumbColor (the on-state
+                // thumb color on web); the prop isn't in react-native's SwitchProps so
+                // TS rejects it on native typings.
+                // @ts-expect-error — web-only prop, see https://necolas.github.io/react-native-web/docs/switch/
+                activeThumbColor={Colors.white}
               />
             </Cell>
           </Row>

--- a/src/components/RegionSummaryCard.tsx
+++ b/src/components/RegionSummaryCard.tsx
@@ -28,23 +28,25 @@ const RegionSummaryCard = observer(function RegionSummaryCard() {
   }
   const statusText =
     statusParts.length === 0 ? t("regionSummary.allNormal") : statusParts.join(" · ");
-  const statusLabelType =
-    counts.flooding > 0 ? "danger" : counts.nearFlooding > 0 ? "warning" : "success";
+
+  let statusLabelType: keyof typeof LARGE_LABEL_COLORS = "success";
+  if (counts.flooding > 0) {
+    statusLabelType = "danger";
+  } else if (counts.nearFlooding > 0) {
+    statusLabelType = "warning";
+  }
   const statusColor = LARGE_LABEL_COLORS[statusLabelType].textColor;
 
   const severity = forecastsStore.severity as ForecastSeverity;
-  const forecastLabelType =
-    severity === ForecastSeverity.Flood
-      ? "danger"
-      : severity === ForecastSeverity.Near
-      ? "warning"
-      : "success";
-  const forecastCopy =
-    severity === ForecastSeverity.Flood
-      ? t("regionSummary.floodingPredicted")
-      : severity === ForecastSeverity.Near
-      ? t("regionSummary.nearFloodPredicted")
-      : t("regionSummary.noFloodingPredicted");
+  let forecastLabelType: keyof typeof LARGE_LABEL_COLORS = "success";
+  let forecastCopy = t("regionSummary.noFloodingPredicted");
+  if (severity === ForecastSeverity.Flood) {
+    forecastLabelType = "danger";
+    forecastCopy = t("regionSummary.floodingPredicted");
+  } else if (severity === ForecastSeverity.Near) {
+    forecastLabelType = "warning";
+    forecastCopy = t("regionSummary.nearFloodPredicted");
+  }
   const forecastColor = LARGE_LABEL_COLORS[forecastLabelType].textColor;
   const forecastBg = LARGE_LABEL_COLORS[forecastLabelType].backgroundColor;
 

--- a/src/components/__tests__/HiddenGageItem.test.tsx
+++ b/src/components/__tests__/HiddenGageItem.test.tsx
@@ -31,11 +31,11 @@ jest.mock("@common-ui/contexts/LocaleContext", () => ({
 
 describe("HiddenGageItem", () => {
   it("renders the location name, location id, Offline pill, and 'No recent data'", () => {
-    const { getByText } = render(
-      <HiddenGageItem
-        item={{ locationId: "USGS-23", locationName: "Tolt River — Above Carnation" }}
-      />
-    );
+    const item = {
+      locationId: "USGS-23",
+      locationInfo: { locationName: "Tolt River — Above Carnation" },
+    } as any;
+    const { getByText } = render(<HiddenGageItem item={item} />);
     expect(getByText("Tolt River — Above Carnation")).toBeTruthy();
     expect(getByText("USGS-23")).toBeTruthy();
     expect(getByText("Offline")).toBeTruthy();

--- a/src/components/__tests__/HiddenGageItem.test.tsx
+++ b/src/components/__tests__/HiddenGageItem.test.tsx
@@ -21,7 +21,7 @@ jest.mock("@common-ui/contexts/LocaleContext", () => ({
   useLocale: () => ({
     t: (key: string) => {
       const map: Record<string, string> = {
-        "regionSummary.offlineGauge": "OFFLINE",
+        "statuses.Offline": "Offline",
         "regionSummary.noRecentData": "No recent data",
       };
       return map[key] ?? key;
@@ -30,7 +30,7 @@ jest.mock("@common-ui/contexts/LocaleContext", () => ({
 }));
 
 describe("HiddenGageItem", () => {
-  it("renders the location name, location id, OFFLINE pill, and 'No recent data'", () => {
+  it("renders the location name, location id, Offline pill, and 'No recent data'", () => {
     const { getByText } = render(
       <HiddenGageItem
         item={{ locationId: "USGS-23", locationName: "Tolt River — Above Carnation" }}
@@ -38,7 +38,7 @@ describe("HiddenGageItem", () => {
     );
     expect(getByText("Tolt River — Above Carnation")).toBeTruthy();
     expect(getByText("USGS-23")).toBeTruthy();
-    expect(getByText("OFFLINE")).toBeTruthy();
+    expect(getByText("Offline")).toBeTruthy();
     expect(getByText("No recent data")).toBeTruthy();
   });
 });

--- a/src/components/__tests__/HiddenGageItem.test.tsx
+++ b/src/components/__tests__/HiddenGageItem.test.tsx
@@ -6,10 +6,6 @@ import { render } from "@testing-library/react-native";
 
 import HiddenGageItem from "../HiddenGageItem";
 
-jest.mock("mobx-react-lite", () => ({
-  observer: (fn: any) => fn,
-}));
-
 jest.mock("expo-router", () => ({
   Link: ({ children }: any) => children,
   useRouter: () => ({ push: jest.fn() }),
@@ -33,18 +29,13 @@ jest.mock("@common-ui/contexts/LocaleContext", () => ({
   }),
 }));
 
-const makeStub = (overrides: Record<string, unknown> = {}) =>
-  ({
-    locationId: "USGS-23",
-    _isStub: true,
-    isOffline: true,
-    locationInfo: { locationName: "Tolt River — Above Carnation" },
-    ...overrides,
-  } as any);
-
 describe("HiddenGageItem", () => {
   it("renders the location name, location id, OFFLINE pill, and 'No recent data'", () => {
-    const { getByText } = render(<HiddenGageItem item={makeStub()} />);
+    const { getByText } = render(
+      <HiddenGageItem
+        item={{ locationId: "USGS-23", locationName: "Tolt River — Above Carnation" }}
+      />
+    );
     expect(getByText("Tolt River — Above Carnation")).toBeTruthy();
     expect(getByText("USGS-23")).toBeTruthy();
     expect(getByText("OFFLINE")).toBeTruthy();

--- a/src/components/__tests__/HiddenGageItem.test.tsx
+++ b/src/components/__tests__/HiddenGageItem.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+import HiddenGageItem from "../HiddenGageItem";
+
+jest.mock("mobx-react-lite", () => ({
+  observer: (fn: any) => fn,
+}));
+
+jest.mock("expo-router", () => ({
+  Link: ({ children }: any) => children,
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("app/_layout", () => ({
+  ROUTES: {
+    GageDetails: "/gage/[id]",
+  },
+}));
+
+jest.mock("@common-ui/contexts/LocaleContext", () => ({
+  useLocale: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        "regionSummary.offlineGauge": "OFFLINE",
+        "regionSummary.noRecentData": "No recent data",
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+const makeStub = (overrides: Record<string, unknown> = {}) =>
+  ({
+    locationId: "USGS-23",
+    _isStub: true,
+    isOffline: true,
+    locationInfo: { locationName: "Tolt River — Above Carnation" },
+    ...overrides,
+  } as any);
+
+describe("HiddenGageItem", () => {
+  it("renders the location name, location id, OFFLINE pill, and 'No recent data'", () => {
+    const { getByText } = render(<HiddenGageItem item={makeStub()} />);
+    expect(getByText("Tolt River — Above Carnation")).toBeTruthy();
+    expect(getByText("USGS-23")).toBeTruthy();
+    expect(getByText("OFFLINE")).toBeTruthy();
+    expect(getByText("No recent data")).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/MapLibreWebGageMap.test.tsx
+++ b/src/components/__tests__/MapLibreWebGageMap.test.tsx
@@ -31,8 +31,8 @@ jest.mock("../TrendIcon", () => ({
   TREND_ICON_TYPES: { Map: "Map" },
 }));
 
-const MockMap = MapLibre.Map as jest.Mock;
-const MockMarker = MapLibre.Marker as jest.Mock;
+const MockMap = MapLibre.Map as unknown as jest.Mock;
+const MockMarker = MapLibre.Marker as unknown as jest.Mock;
 
 const makeGage = (overrides: Record<string, unknown> = {}) =>
   ({ locationId: "test", latitude: 47.5, longitude: -121.8, ...overrides } as any);

--- a/src/components/__tests__/RegionSummaryCard.test.tsx
+++ b/src/components/__tests__/RegionSummaryCard.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+import RegionSummaryCard from "../RegionSummaryCard";
+
+jest.mock("mobx-react-lite", () => ({
+  observer: (fn: any) => fn,
+}));
+
+jest.mock("expo-router", () => ({
+  Link: ({ children }: any) => children,
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("app/_layout", () => ({
+  ROUTES: { Forecast: "/forecast" },
+}));
+
+jest.mock("@common-ui/contexts/LocaleContext", () => ({
+  useLocale: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      const map: Record<string, string> = {
+        "regionSummary.allNormal": "All gauges normal",
+        "regionSummary.flooding": `${opts?.count} flooding`,
+        "regionSummary.nearFlooding": `${opts?.count} near flooding`,
+        "regionSummary.noFloodingPredicted": "No flooding predicted",
+        "regionSummary.nearFloodPredicted": "Near-flood predicted",
+        "regionSummary.floodingPredicted": "Flooding predicted",
+        "regionSummary.active": "active",
+        "regionSummary.offline": "offline",
+        "regionSummary.hidden": "hidden",
+        "regionSummary.showHidden": "Show hidden",
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+let mockStores: any = {};
+jest.mock("@models/helpers/useStores", () => ({
+  useStores: () => mockStores,
+}));
+
+jest.mock("@common-ui/utils/responsive", () => ({
+  useResponsive: () => ({ isMobile: false }),
+  isWeb: true,
+}));
+
+const setup = (overrides: Partial<typeof mockStores> = {}) => {
+  mockStores = {
+    showHiddenOffline: false,
+    setShowHiddenOffline: jest.fn(),
+    getBucketCounts: () => ({
+      active: 9,
+      visibleOffline: 0,
+      hidden: 12,
+      flooding: 0,
+      nearFlooding: 0,
+    }),
+    forecastsStore: { severity: "none" },
+    ...overrides,
+  };
+};
+
+describe("RegionSummaryCard", () => {
+  it("renders calm-state copy when nothing is flooding", () => {
+    setup();
+    const { getByText } = render(<RegionSummaryCard />);
+    expect(getByText("All gauges normal")).toBeTruthy();
+    expect(getByText("No flooding predicted")).toBeTruthy();
+  });
+
+  it("renders flood + near-flood status when both are present", () => {
+    setup({
+      getBucketCounts: () => ({
+        active: 5,
+        visibleOffline: 0,
+        hidden: 12,
+        flooding: 3,
+        nearFlooding: 2,
+      }),
+      forecastsStore: { severity: "flood" },
+    });
+    const { getByText } = render(<RegionSummaryCard />);
+    expect(getByText("3 flooding")).toBeTruthy();
+    expect(getByText("2 near flooding")).toBeTruthy();
+    expect(getByText("Flooding predicted")).toBeTruthy();
+  });
+
+  it("disables the toggle when hidden count is zero", () => {
+    setup({
+      getBucketCounts: () => ({
+        active: 9,
+        visibleOffline: 0,
+        hidden: 0,
+        flooding: 0,
+        nearFlooding: 0,
+      }),
+    });
+    const { getByTestId } = render(<RegionSummaryCard />);
+    expect(getByTestId("region-summary-toggle").props.disabled).toBe(true);
+  });
+
+  it("calls setShowHiddenOffline when the toggle is flipped", () => {
+    setup();
+    const { getByTestId } = render(<RegionSummaryCard />);
+    fireEvent(getByTestId("region-summary-toggle"), "valueChange", true);
+    expect(mockStores.setShowHiddenOffline).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/components/__tests__/RegionSummaryCard.test.tsx
+++ b/src/components/__tests__/RegionSummaryCard.test.tsx
@@ -110,4 +110,21 @@ describe("RegionSummaryCard", () => {
     fireEvent(getByTestId("region-summary-toggle"), "valueChange", true);
     expect(mockStores.setShowHiddenOffline).toHaveBeenCalledWith(true);
   });
+
+  it("rolls hidden gauges into the offline count (hidden gauges are also offline)", () => {
+    setup({
+      getBucketCounts: () => ({
+        active: 9,
+        visibleOffline: 2,
+        hidden: 3,
+        flooding: 0,
+        nearFlooding: 0,
+      }),
+    });
+    const { getByText } = render(<RegionSummaryCard />);
+    expect(getByText("9")).toBeTruthy(); // active
+    expect(getByText("3")).toBeTruthy(); // hidden
+    // 2 visibleOffline + 3 hidden = 5 offline
+    expect(getByText("5")).toBeTruthy();
+  });
 });

--- a/src/components/__tests__/RegionSummaryCard.test.tsx
+++ b/src/components/__tests__/RegionSummaryCard.test.tsx
@@ -90,7 +90,7 @@ describe("RegionSummaryCard", () => {
     expect(getByText("Flooding predicted")).toBeTruthy();
   });
 
-  it("disables the toggle when hidden count is zero", () => {
+  it("omits the toggle and hidden parenthetical when hidden count is zero", () => {
     setup({
       getBucketCounts: () => ({
         active: 9,
@@ -100,8 +100,10 @@ describe("RegionSummaryCard", () => {
         nearFlooding: 0,
       }),
     });
-    const { getByTestId } = render(<RegionSummaryCard />);
-    expect(getByTestId("region-summary-toggle").props.disabled).toBe(true);
+    const { queryByTestId, queryByText } = render(<RegionSummaryCard />);
+    expect(queryByTestId("region-summary-toggle")).toBeNull();
+    expect(queryByText("Show hidden")).toBeNull();
+    expect(queryByText("hidden")).toBeNull();
   });
 
   it("calls setShowHiddenOffline when the toggle is flipped", () => {

--- a/src/components/__tests__/RegionSummaryCard.test.tsx
+++ b/src/components/__tests__/RegionSummaryCard.test.tsx
@@ -85,8 +85,8 @@ describe("RegionSummaryCard", () => {
       forecastsStore: { severity: "flood" },
     });
     const { getByText } = render(<RegionSummaryCard />);
-    expect(getByText("3 flooding")).toBeTruthy();
-    expect(getByText("2 near flooding")).toBeTruthy();
+    expect(getByText(/3 flooding/)).toBeTruthy();
+    expect(getByText(/2 near flooding/)).toBeTruthy();
     expect(getByText("Flooding predicted")).toBeTruthy();
   });
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -69,6 +69,21 @@ const en = {
   homeScreen: {
     title: "Snoqualmie River / SVPA",
   },
+  regionSummary: {
+    allNormal: "All gauges normal",
+    flooding: "{{count}} flooding",
+    nearFlooding: "{{count}} near flooding",
+    noFloodingPredicted: "No flooding predicted",
+    nearFloodPredicted: "Near-flood predicted",
+    floodingPredicted: "Flooding predicted",
+    active: "active",
+    offline: "offline",
+    hidden: "hidden",
+    showHidden: "Show hidden",
+    noRecentData: "No recent data",
+    offlineGauge: "OFFLINE",
+    offlineBanner: "Gauge offline — pick a historical event below to see past readings",
+  },
   forecastScreen: {
     title: "Forecast",
     details: "Details",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -82,7 +82,6 @@ const en = {
     showHidden: "Show hidden",
     noRecentData: "No recent data",
     offlineGauge: "OFFLINE",
-    offlineBanner: "Gauge offline — pick a historical event below to see past readings",
   },
   forecastScreen: {
     title: "Forecast",
@@ -283,6 +282,7 @@ const en = {
     rateOfChange: "Rate of Change",
     roadLevel: "Road Level",
     rangeWarning: "Range adjusted to {{maxRange}} days — the maximum this chart supports.",
+    noDataInRange: "No data in selected range",
   },
   gageInfoCard: {
     gageInfo: "Gauge Info",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -81,7 +81,6 @@ const en = {
     hidden: "hidden",
     showHidden: "Show hidden",
     noRecentData: "No recent data",
-    offlineGauge: "OFFLINE",
   },
   forecastScreen: {
     title: "Forecast",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -83,7 +83,6 @@ const es = {
     hidden: "ocultos",
     showHidden: "Mostrar ocultos",
     noRecentData: "Sin datos recientes",
-    offlineGauge: "DESCONECTADO",
   },
   forecastScreen: {
     title: "Pronóstico",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -84,8 +84,6 @@ const es = {
     showHidden: "Mostrar ocultos",
     noRecentData: "Sin datos recientes",
     offlineGauge: "DESCONECTADO",
-    offlineBanner:
-      "Medidor desconectado — selecciona un evento histórico abajo para ver las lecturas anteriores.",
   },
   forecastScreen: {
     title: "Pronóstico",
@@ -288,6 +286,7 @@ const es = {
     rateOfChange: "Tasa de cambio",
     roadLevel: "Nivel de la carretera",
     rangeWarning: "Rango ajustado a {{maxRange}} días — el máximo que admite este gráfico.",
+    noDataInRange: "Sin datos en el rango seleccionado",
   },
   gageInfoCard: {
     gageInfo: "Información del medidor",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -71,6 +71,22 @@ const es = {
   homeScreen: {
     title: "Río Snoqualmie / SVPA",
   },
+  regionSummary: {
+    allNormal: "Todos los medidores normales",
+    flooding: "{{count}} en inundación",
+    nearFlooding: "{{count}} en inundación inminente",
+    noFloodingPredicted: "Sin inundación pronosticada",
+    nearFloodPredicted: "Inundación inminente pronosticada",
+    floodingPredicted: "Inundación pronosticada",
+    active: "activos",
+    offline: "desconectados",
+    hidden: "ocultos",
+    showHidden: "Mostrar ocultos",
+    noRecentData: "Sin datos recientes",
+    offlineGauge: "DESCONECTADO",
+    offlineBanner:
+      "Medidor desconectado — selecciona un evento histórico abajo para ver las lecturas anteriores.",
+  },
   forecastScreen: {
     title: "Pronóstico",
     details: "Detalles",

--- a/src/models/Forecasts.ts
+++ b/src/models/Forecasts.ts
@@ -3,6 +3,7 @@ import { api } from "@services/api";
 import dayjs from "dayjs";
 
 import { dataFetchingProps, withDataFetchingActions } from "./helpers/withDataFetchingProps";
+import { computeForecastSeverity } from "./helpers/regionSummary";
 import Config from "@config/config";
 import { LocationInfoModel } from "./LocationInfo";
 import { GageSummary } from "./RootStore";
@@ -415,6 +416,15 @@ export const ForecastStoreModel = types
   .views((store) => ({
     getForecast(gageId: string) {
       return store.forecasts.get(gageId);
+    },
+
+    get severity() {
+      const inputs = Array.from(store.forecasts.values()).map((f) => ({
+        peaks: f.peaks,
+        dischargeStageOne: f.dischargeStageOne,
+        dischargeStageTwo: f.dischargeStageTwo,
+      }));
+      return computeForecastSeverity(inputs);
     },
   }));
 

--- a/src/models/Gage.ts
+++ b/src/models/Gage.ts
@@ -341,14 +341,11 @@ export const GageStoreModel = types
     gages: types.array(GageModel),
     ...dataFetchingProps,
   })
-  /**
-   * Strip stub gages from snapshots in both directions. Stubs are session-scoped —
-   * they're re-added on the next fetch when `showHiddenOffline` is true (see fetchData
-   * below). Persisting them caused MST to lazy-wrap their child arrays on rehydration
-   * outside any action context, tripping "initializing phase" errors during React
-   * DevTools' commit-phase prop introspection. preProcessSnapshot also cleans up any
-   * stub residue from previously-cached state in AsyncStorage.
-   */
+  // Stub gauges are session-scoped — they're re-added on the next fetch when
+  // `showHiddenOffline` is true (see fetchData below). Filtering them out of the
+  // persisted snapshot keeps AsyncStorage lean and avoids carrying stale stub data
+  // across sessions. setupRootStore.ts also strips stubs on load as belt-and-suspenders
+  // for state cached by older builds that didn't have postProcessSnapshot.
   .preProcessSnapshot((snapshot) => ({
     ...snapshot,
     gages: (snapshot?.gages ?? []).filter((g: any) => !g?._isStub),

--- a/src/models/Gage.ts
+++ b/src/models/Gage.ts
@@ -100,6 +100,7 @@ export const GageModel = types
     locationName: types.maybe(types.string),
     locationId: types.identifier,
     isOffline: types.maybe(types.boolean),
+    _isStub: types.optional(types.boolean, false),
     rank: types.maybe(types.number),
     deviceTypeName: types.maybe(types.string),
     timeZoneName: types.maybe(types.string),

--- a/src/models/Gage.ts
+++ b/src/models/Gage.ts
@@ -387,7 +387,12 @@ export const GageStoreModel = types
           .subtract(Config.FRONT_PAGE_CHART_DURATION_NUMBER, Config.FRONT_PAGE_CHART_DURATION_UNIT)
           .utc()
           .format();
-      const gage = store.gages.find((gage) => gage?.locationId === locationId);
+      let gage = store.gages.find((g) => g?.locationId === locationId);
+
+      if (!gage) {
+        store.gages.push(makeStubSnapshot(locationId) as any);
+        gage = store.gages.find((g) => g?.locationId === locationId);
+      }
 
       if (!gage) {
         store.setIsFetching(false);

--- a/src/models/Gage.ts
+++ b/src/models/Gage.ts
@@ -497,19 +497,6 @@ export const GageStoreModel = types
       for (const id of toAdd) {
         store.gages.push(makeStubSnapshot(id) as any);
       }
-      // MST 7 bug github.com/mobxjs/mobx-state-tree#2279: empty types.array(...)
-      // child observables aren't materialized when their parent is created. React 19's
-      // dev-mode `logComponentRender` profiler (NOT the React DevTools browser
-      // extension — this fires even without it) is then the first reader of those
-      // children and trips MST's "initializing phase" assertion, poisoning the commit.
-      // Touching each lazy array INSIDE this action context forces materialization
-      // while it's legal. We do it for every gauge (not just new stubs) because real
-      // gauges also have empty `actualReadings`/`predictions` arrays.
-      for (const g of store.gages) {
-        void g.readings.length;
-        void g.actualReadings.length;
-        void g.predictions.length;
-      }
     };
 
     return {

--- a/src/models/Gage.ts
+++ b/src/models/Gage.ts
@@ -1,4 +1,12 @@
-import { Instance, SnapshotIn, SnapshotOut, types, flow, getRoot } from "mobx-state-tree";
+import {
+  Instance,
+  SnapshotIn,
+  SnapshotOut,
+  types,
+  flow,
+  getRoot,
+  getSnapshot,
+} from "mobx-state-tree";
 import { api } from "@services/api";
 import dayjs from "dayjs";
 
@@ -333,6 +341,22 @@ export const GageStoreModel = types
     gages: types.array(GageModel),
     ...dataFetchingProps,
   })
+  /**
+   * Strip stub gages from snapshots in both directions. Stubs are session-scoped —
+   * they're re-added on the next fetch when `showHiddenOffline` is true (see fetchData
+   * below). Persisting them caused MST to lazy-wrap their child arrays on rehydration
+   * outside any action context, tripping "initializing phase" errors during React
+   * DevTools' commit-phase prop introspection. preProcessSnapshot also cleans up any
+   * stub residue from previously-cached state in AsyncStorage.
+   */
+  .preProcessSnapshot((snapshot) => ({
+    ...snapshot,
+    gages: (snapshot?.gages ?? []).filter((g: any) => !g?._isStub),
+  }))
+  .postProcessSnapshot((snapshot) => ({
+    ...snapshot,
+    gages: snapshot.gages.filter((g) => !g._isStub),
+  }))
   .actions(withDataFetchingActions)
   .actions(withSetPropAction)
   .actions((store) => {
@@ -358,7 +382,14 @@ export const GageStoreModel = types
             locationInfo: gage.locationId,
           })) || [];
 
-        store.gages = gages;
+        // Preserve existing stub gauges across the reassignment. MST's identifier
+        // reconciliation will keep stubs alive when they appear in the new array
+        // (matched by locationId). Without this, fetchData destroys the stubs and
+        // syncHiddenStubs recreates them — leaving dead old MST nodes that React 19's
+        // dev-mode commit-phase prop diff still references, firing thousands of
+        // non-fatal "Path upon death" warnings (MST liveliness checking).
+        const stubSnapshots = store.gages.filter((g) => g._isStub).map((g) => getSnapshot(g));
+        store.gages = [...gages, ...stubSnapshots] as any;
       } else {
         store.setError(response.kind);
       }
@@ -468,6 +499,19 @@ export const GageStoreModel = types
       });
       for (const id of toAdd) {
         store.gages.push(makeStubSnapshot(id) as any);
+      }
+      // MST 7 bug github.com/mobxjs/mobx-state-tree#2279: empty types.array(...)
+      // child observables aren't materialized when their parent is created. React 19's
+      // dev-mode `logComponentRender` profiler (NOT the React DevTools browser
+      // extension — this fires even without it) is then the first reader of those
+      // children and trips MST's "initializing phase" assertion, poisoning the commit.
+      // Touching each lazy array INSIDE this action context forces materialization
+      // while it's legal. We do it for every gauge (not just new stubs) because real
+      // gauges also have empty `actualReadings`/`predictions` arrays.
+      for (const g of store.gages) {
+        void g.readings.length;
+        void g.actualReadings.length;
+        void g.predictions.length;
       }
     };
 

--- a/src/models/Gage.ts
+++ b/src/models/Gage.ts
@@ -10,6 +10,7 @@ import { LocationInfoModel } from "./LocationInfo";
 import localDayJs from "@services/localDayJs";
 import { DataPoint, NOAAForecastModel } from "./Forecasts";
 import USGS_INFO from "@utils/usgsInfo";
+import { computeStubChanges, makeStubSnapshot } from "./helpers/regionSummary";
 
 // Gage data from https://waterservices.usgs.gov/rest/IV-Service.html
 // id: "USGS-38",
@@ -433,9 +434,32 @@ export const GageStoreModel = types
       store.setIsFetching(false);
     });
 
+    const syncHiddenStubs = (
+      showHidden: boolean,
+      locationInfos: readonly { id: string; isMetagage?: boolean }[]
+    ) => {
+      const { toAdd, toRemove } = computeStubChanges({
+        gages: store.gages,
+        locationInfos,
+        showHidden,
+      });
+
+      for (const id of toRemove) {
+        const existing = store.gages.find((g) => g.locationId === id && g._isStub);
+        if (existing) {
+          store.gages.remove(existing);
+        }
+      }
+
+      for (const id of toAdd) {
+        store.gages.push(makeStubSnapshot(id) as any);
+      }
+    };
+
     return {
       fetchData,
       fetchDataForGage,
+      syncHiddenStubs,
     };
   })
   .views((store) => ({

--- a/src/models/Gage.ts
+++ b/src/models/Gage.ts
@@ -444,23 +444,28 @@ export const GageStoreModel = types
       store.setIsFetching(false);
     });
 
+    /**
+     * Idempotently adds hidden-location stubs to store.gages when showHidden is true.
+     *
+     * IMPORTANT: this action never *removes* stubs. The display layer hides them when
+     * the toggle is off (see RootStore.getDisplayItems). Removing nodes from an MST
+     * array detaches them; React DevTools then introspects the detached props during
+     * the commit phase and trips MST's "Path upon death" / "initializing phase" errors.
+     * Keeping stubs in the tree permanently sidesteps both issues, and stubs hydrated
+     * with readings via fetchDataForGage retain their data across toggle cycles.
+     */
     const syncHiddenStubs = (
       showHidden: boolean,
       locationInfos: readonly { id: string; isMetagage?: boolean }[]
     ) => {
-      const { toAdd, toRemove } = computeStubChanges({
+      if (!showHidden) {
+        return;
+      }
+      const { toAdd } = computeStubChanges({
         gages: store.gages,
         locationInfos,
         showHidden,
       });
-
-      for (const id of toRemove) {
-        const existing = store.gages.find((g) => g.locationId === id && g._isStub);
-        if (existing) {
-          store.gages.remove(existing);
-        }
-      }
-
       for (const id of toAdd) {
         store.gages.push(makeStubSnapshot(id) as any);
       }

--- a/src/models/Gage.ts
+++ b/src/models/Gage.ts
@@ -363,6 +363,11 @@ export const GageStoreModel = types
         store.setError(response.kind);
       }
 
+      const root = getRoot<any>(store);
+      if (root.showHiddenOffline) {
+        syncHiddenStubs(true, root.locationInfoStore.locationInfos);
+      }
+
       store.setIsFetching(false);
     });
 

--- a/src/models/RootStore.ts
+++ b/src/models/RootStore.ts
@@ -5,6 +5,7 @@ import { GageReadingStoreModel } from "./GageReading";
 import { LocationInfoModelStore } from "./LocationInfo";
 import { RegionModelStore } from "./Region";
 import { AuthSessionStoreModel } from "./AuthSession";
+import { computeBucketCounts } from "./helpers/regionSummary";
 
 /**
  * A RootStore model.
@@ -97,15 +98,34 @@ export const RootStoreModel = types
         .map((location) => location.id);
     };
 
+    const realLocations = () => store.locationInfoStore.locationInfos.filter((l) => !l.isMetagage);
+
+    const hiddenLocations = () => {
+      const realGageIds = new Set(
+        store.gagesStore.gages.filter((g) => !g._isStub).map((g) => g.locationId)
+      );
+      return realLocations().filter((l) => !realGageIds.has(l.id));
+    };
+
+    const getBucketCounts = () =>
+      computeBucketCounts({
+        gages: store.gagesStore.gages,
+        locationInfos: store.locationInfoStore.locationInfos,
+      });
+
+    const navLocations = () => {
+      if (store.showHiddenOffline) {
+        return realLocations();
+      }
+      return filterLocationsWithGages();
+    };
+
     const getUpstreamGageLocation = (locationId: string) => {
       if (!locationId) {
         return null;
       }
-
-      const locations = filterLocationsWithGages();
-
+      const locations = navLocations();
       const gageIndex = locations.findIndex((location) => location.id === locationId);
-
       return gageIndex > 0 && locations[gageIndex - 1];
     };
 
@@ -113,11 +133,8 @@ export const RootStoreModel = types
       if (!locationId) {
         return null;
       }
-
-      const locations = filterLocationsWithGages();
-
+      const locations = navLocations();
       const gageIndex = locations.findIndex((location) => location.id === locationId);
-
       return gageIndex >= 0 && gageIndex + 1 < locations.length && locations[gageIndex + 1];
     };
 
@@ -130,6 +147,9 @@ export const RootStoreModel = types
       getLocationWithGagesIds,
       getUpstreamGageLocation,
       getDownstreamGageLocation,
+      realLocations,
+      hiddenLocations,
+      getBucketCounts,
 
       get isDataFetched() {
         return store.isFetched;

--- a/src/models/RootStore.ts
+++ b/src/models/RootStore.ts
@@ -73,17 +73,25 @@ export const RootStoreModel = types
       return store.regionStore?.region?.timezone || "America/Los_Angeles";
     };
 
-    const filterLocationsWithGages = () => {
+    /**
+     * Returns gages eligible for display / nav. When the toggle is off, stubs are
+     * filtered out — they remain in the MST tree but are invisible. When on, both
+     * real gages and stubs are returned.
+     */
+    const visibleGages = () => {
       const gages = store.gagesStore.gages;
-      const gageIds = gages.map((gage) => gage.locationId);
+      return store.showHiddenOffline ? gages : gages.filter((g) => !g._isStub);
+    };
 
+    const filterLocationsWithGages = () => {
+      const gageIds = visibleGages().map((gage) => gage.locationId);
       return store.locationInfoStore.locationInfos.filter((location) =>
         gageIds.includes(location.id)
       );
     };
 
     const getLocationsWithGages = () => {
-      const gages = store.gagesStore.gages;
+      const gages = visibleGages();
       const gageIds = gages.map((gage) => gage.locationId);
 
       return store.locationInfoStore.locationInfos
@@ -92,7 +100,7 @@ export const RootStoreModel = types
     };
 
     const getLocationWithGagesIds = () => {
-      const gages = store.gagesStore.gages.map((gage) => gage.locationId);
+      const gages = visibleGages().map((gage) => gage.locationId);
       return store.locationInfoStore.locationInfos
         .filter((location) => gages.includes(location.id))
         .map((location) => location.id);

--- a/src/models/RootStore.ts
+++ b/src/models/RootStore.ts
@@ -26,6 +26,11 @@ export const RootStoreModel = types
       store.isFetched = isFetching;
     };
 
+    const setShowHiddenOffline = (value: boolean) => {
+      store.showHiddenOffline = value;
+      store.gagesStore.syncHiddenStubs(value, store.locationInfoStore.locationInfos);
+    };
+
     const fetchMainData = flow(function* () {
       setIsFetched(false);
 
@@ -39,6 +44,7 @@ export const RootStoreModel = types
 
     return {
       fetchMainData,
+      setShowHiddenOffline,
     };
   })
   .views((store) => {

--- a/src/models/RootStore.ts
+++ b/src/models/RootStore.ts
@@ -13,6 +13,7 @@ export const RootStoreModel = types
   .model("RootStore")
   .props({
     isFetched: types.optional(types.boolean, false),
+    showHiddenOffline: types.optional(types.boolean, false),
     gagesStore: types.optional(GageStoreModel, {}),
     gageReadingsStore: types.optional(GageReadingStoreModel, {}),
     regionStore: types.optional(RegionModelStore, {}),

--- a/src/models/__tests__/syncHiddenStubs.test.ts
+++ b/src/models/__tests__/syncHiddenStubs.test.ts
@@ -1,0 +1,70 @@
+import { types } from "mobx-state-tree";
+import { GageStoreModel } from "../Gage";
+
+const LocationStub = types.model("LocationStub", {
+  id: types.identifier,
+  isMetagage: types.optional(types.boolean, false),
+});
+
+describe("GageStore.syncHiddenStubs", () => {
+  const buildStore = () => {
+    const store = GageStoreModel.create({
+      gages: [
+        { locationId: "A", _isStub: false } as any,
+        { locationId: "B", _isStub: false } as any,
+      ],
+    });
+    return store;
+  };
+
+  const locations = [
+    LocationStub.create({ id: "A" }),
+    LocationStub.create({ id: "B" }),
+    LocationStub.create({ id: "C" }),
+    LocationStub.create({ id: "D" }),
+    LocationStub.create({ id: "META", isMetagage: true }),
+  ];
+
+  it("adds stubs for hidden locations when called with showHidden=true", () => {
+    const store = buildStore();
+    store.syncHiddenStubs(true, locations);
+
+    const ids = store.gages.map((g) => g.locationId).sort();
+    expect(ids).toEqual(["A", "B", "C", "D"]);
+    const stub = store.gages.find((g) => g.locationId === "C");
+    expect(stub?._isStub).toBe(true);
+    expect(stub?.isOffline).toBe(true);
+  });
+
+  it("removes all stubs when called with showHidden=false", () => {
+    const store = buildStore();
+    store.syncHiddenStubs(true, locations);
+    store.syncHiddenStubs(false, locations);
+    expect(store.gages.map((g) => g.locationId).sort()).toEqual(["A", "B"]);
+    expect(store.gages.every((g) => !g._isStub)).toBe(true);
+  });
+
+  it("preserves the MST identity of real gauges across repeated sync calls", () => {
+    const store = buildStore();
+    const realA = store.gages.find((g) => g.locationId === "A");
+    store.syncHiddenStubs(true, locations);
+    store.syncHiddenStubs(false, locations);
+    store.syncHiddenStubs(true, locations);
+    const realAAfter = store.gages.find((g) => g.locationId === "A");
+    expect(realAAfter).toBe(realA);
+  });
+
+  it("is idempotent — a second call with the same inputs is a no-op", () => {
+    const store = buildStore();
+    store.syncHiddenStubs(true, locations);
+    const snapshotIds = store.gages.map((g) => g.locationId);
+    store.syncHiddenStubs(true, locations);
+    expect(store.gages.map((g) => g.locationId)).toEqual(snapshotIds);
+  });
+
+  it("skips metagage locations when building stubs", () => {
+    const store = buildStore();
+    store.syncHiddenStubs(true, locations);
+    expect(store.gages.find((g) => g.locationId === "META")).toBeUndefined();
+  });
+});

--- a/src/models/__tests__/syncHiddenStubs.test.ts
+++ b/src/models/__tests__/syncHiddenStubs.test.ts
@@ -36,12 +36,29 @@ describe("GageStore.syncHiddenStubs", () => {
     expect(stub?.isOffline).toBe(true);
   });
 
-  it("removes all stubs when called with showHidden=false", () => {
+  it("is a no-op when called with showHidden=false — stubs persist in the tree (display layer hides them)", () => {
     const store = buildStore();
     store.syncHiddenStubs(true, locations);
+    const beforeIds = store.gages.map((g) => g.locationId).sort();
     store.syncHiddenStubs(false, locations);
-    expect(store.gages.map((g) => g.locationId).sort()).toEqual(["A", "B"]);
-    expect(store.gages.every((g) => !g._isStub)).toBe(true);
+    // Stubs must NOT be removed: removing detaches MST nodes, and React DevTools'
+    // commit-phase prop introspection then trips "Path upon death" /
+    // "initializing phase" errors. The toggle filters at the display layer instead.
+    const afterIds = store.gages.map((g) => g.locationId).sort();
+    expect(afterIds).toEqual(beforeIds);
+    const stubC = store.gages.find((g) => g.locationId === "C");
+    expect(stubC?._isStub).toBe(true);
+  });
+
+  it("materializes lazy MST arrays on the stub so devtools reads don't trip 'initializing phase'", () => {
+    const store = buildStore();
+    store.syncHiddenStubs(true, locations);
+    const stub = store.gages.find((g) => g.locationId === "C");
+    // Reading these properties from outside an action must not throw — these are the
+    // exact reads React DevTools performs when logging component props post-commit.
+    expect(() => stub?.readings.length).not.toThrow();
+    expect(() => stub?.actualReadings.length).not.toThrow();
+    expect(() => stub?.predictions.length).not.toThrow();
   });
 
   it("preserves the MST identity of real gauges across repeated sync calls", () => {

--- a/src/models/helpers/__tests__/regionSummary.test.ts
+++ b/src/models/helpers/__tests__/regionSummary.test.ts
@@ -197,15 +197,12 @@ describe("computeStubChanges", () => {
 });
 
 describe("makeStubSnapshot", () => {
-  it("returns a snapshot with explicit empty arrays so MST materializes them in init phase", () => {
+  it("returns the minimal snapshot shape for a stub gauge", () => {
     expect(makeStubSnapshot("USGS-23")).toEqual({
       locationId: "USGS-23",
       locationInfo: "USGS-23",
       isOffline: true,
       _isStub: true,
-      readings: [],
-      actualReadings: [],
-      predictions: [],
     });
   });
 });

--- a/src/models/helpers/__tests__/regionSummary.test.ts
+++ b/src/models/helpers/__tests__/regionSummary.test.ts
@@ -206,6 +206,9 @@ describe("makeStubSnapshot", () => {
       locationInfo: "USGS-23",
       isOffline: true,
       _isStub: true,
+      readings: [],
+      actualReadings: [],
+      predictions: [],
     });
   });
 });

--- a/src/models/helpers/__tests__/regionSummary.test.ts
+++ b/src/models/helpers/__tests__/regionSummary.test.ts
@@ -1,0 +1,61 @@
+import { computeForecastSeverity } from "../regionSummary";
+
+describe("computeForecastSeverity", () => {
+  it("returns 'none' for an empty input", () => {
+    expect(computeForecastSeverity([])).toBe("none");
+  });
+
+  it("returns 'none' when all peaks are below stageOne", () => {
+    expect(
+      computeForecastSeverity([
+        { peaks: [{ waterDischarge: 100 }], dischargeStageOne: 500, dischargeStageTwo: 1000 },
+      ])
+    ).toBe("none");
+  });
+
+  it("returns 'near' when a peak is at or above stageOne but below stageTwo", () => {
+    expect(
+      computeForecastSeverity([
+        { peaks: [{ waterDischarge: 500 }], dischargeStageOne: 500, dischargeStageTwo: 1000 },
+      ])
+    ).toBe("near");
+  });
+
+  it("returns 'flood' when any peak is at or above stageTwo", () => {
+    expect(
+      computeForecastSeverity([
+        { peaks: [{ waterDischarge: 1000 }], dischargeStageOne: 500, dischargeStageTwo: 1000 },
+      ])
+    ).toBe("flood");
+  });
+
+  it("returns 'flood' when one forecast is near and another is flood", () => {
+    expect(
+      computeForecastSeverity([
+        { peaks: [{ waterDischarge: 600 }], dischargeStageOne: 500, dischargeStageTwo: 1000 },
+        { peaks: [{ waterDischarge: 1500 }], dischargeStageOne: 500, dischargeStageTwo: 1000 },
+      ])
+    ).toBe("flood");
+  });
+
+  it("skips peaks with null waterDischarge", () => {
+    expect(
+      computeForecastSeverity([
+        {
+          peaks: [{ waterDischarge: null }, { waterDischarge: 1500 }],
+          dischargeStageOne: 500,
+          dischargeStageTwo: 1000,
+        },
+      ])
+    ).toBe("flood");
+  });
+
+  it("returns 'none' when thresholds are missing or zero", () => {
+    expect(computeForecastSeverity([{ peaks: [{ waterDischarge: 9999 }] }])).toBe("none");
+    expect(
+      computeForecastSeverity([
+        { peaks: [{ waterDischarge: 9999 }], dischargeStageOne: 0, dischargeStageTwo: 0 },
+      ])
+    ).toBe("none");
+  });
+});

--- a/src/models/helpers/__tests__/regionSummary.test.ts
+++ b/src/models/helpers/__tests__/regionSummary.test.ts
@@ -3,44 +3,45 @@ import {
   computeBucketCounts,
   computeStubChanges,
   makeStubSnapshot,
+  ForecastSeverity,
 } from "../regionSummary";
 
 describe("computeForecastSeverity", () => {
-  it("returns 'none' for an empty input", () => {
-    expect(computeForecastSeverity([])).toBe("none");
+  it("returns None for an empty input", () => {
+    expect(computeForecastSeverity([])).toBe(ForecastSeverity.None);
   });
 
-  it("returns 'none' when all peaks are below stageOne", () => {
+  it("returns None when all peaks are below stageOne", () => {
     expect(
       computeForecastSeverity([
         { peaks: [{ waterDischarge: 100 }], dischargeStageOne: 500, dischargeStageTwo: 1000 },
       ])
-    ).toBe("none");
+    ).toBe(ForecastSeverity.None);
   });
 
-  it("returns 'near' when a peak is at or above stageOne but below stageTwo", () => {
+  it("returns Near when a peak is at or above stageOne but below stageTwo", () => {
     expect(
       computeForecastSeverity([
         { peaks: [{ waterDischarge: 500 }], dischargeStageOne: 500, dischargeStageTwo: 1000 },
       ])
-    ).toBe("near");
+    ).toBe(ForecastSeverity.Near);
   });
 
-  it("returns 'flood' when any peak is at or above stageTwo", () => {
+  it("returns Flood when any peak is at or above stageTwo", () => {
     expect(
       computeForecastSeverity([
         { peaks: [{ waterDischarge: 1000 }], dischargeStageOne: 500, dischargeStageTwo: 1000 },
       ])
-    ).toBe("flood");
+    ).toBe(ForecastSeverity.Flood);
   });
 
-  it("returns 'flood' when one forecast is near and another is flood", () => {
+  it("returns Flood when one forecast is near and another is flood", () => {
     expect(
       computeForecastSeverity([
         { peaks: [{ waterDischarge: 600 }], dischargeStageOne: 500, dischargeStageTwo: 1000 },
         { peaks: [{ waterDischarge: 1500 }], dischargeStageOne: 500, dischargeStageTwo: 1000 },
       ])
-    ).toBe("flood");
+    ).toBe(ForecastSeverity.Flood);
   });
 
   it("skips peaks with null waterDischarge", () => {
@@ -52,16 +53,18 @@ describe("computeForecastSeverity", () => {
           dischargeStageTwo: 1000,
         },
       ])
-    ).toBe("flood");
+    ).toBe(ForecastSeverity.Flood);
   });
 
-  it("returns 'none' when thresholds are missing or zero", () => {
-    expect(computeForecastSeverity([{ peaks: [{ waterDischarge: 9999 }] }])).toBe("none");
+  it("returns None when thresholds are missing or zero", () => {
+    expect(computeForecastSeverity([{ peaks: [{ waterDischarge: 9999 }] }])).toBe(
+      ForecastSeverity.None
+    );
     expect(
       computeForecastSeverity([
         { peaks: [{ waterDischarge: 9999 }], dischargeStageOne: 0, dischargeStageTwo: 0 },
       ])
-    ).toBe("none");
+    ).toBe(ForecastSeverity.None);
   });
 });
 

--- a/src/models/helpers/__tests__/regionSummary.test.ts
+++ b/src/models/helpers/__tests__/regionSummary.test.ts
@@ -197,12 +197,15 @@ describe("computeStubChanges", () => {
 });
 
 describe("makeStubSnapshot", () => {
-  it("returns a minimal snapshot suitable for GageStore.gages.push", () => {
+  it("returns a snapshot with explicit empty arrays so MST materializes them in init phase", () => {
     expect(makeStubSnapshot("USGS-23")).toEqual({
       locationId: "USGS-23",
       locationInfo: "USGS-23",
       isOffline: true,
       _isStub: true,
+      readings: [],
+      actualReadings: [],
+      predictions: [],
     });
   });
 });

--- a/src/models/helpers/__tests__/regionSummary.test.ts
+++ b/src/models/helpers/__tests__/regionSummary.test.ts
@@ -1,4 +1,9 @@
-import { computeForecastSeverity, computeBucketCounts } from "../regionSummary";
+import {
+  computeForecastSeverity,
+  computeBucketCounts,
+  computeStubChanges,
+  makeStubSnapshot,
+} from "../regionSummary";
 
 describe("computeForecastSeverity", () => {
   it("returns 'none' for an empty input", () => {
@@ -125,5 +130,79 @@ describe("computeBucketCounts", () => {
         locationInfos: [loc("A"), loc("META/AGE", true)],
       })
     ).toEqual({ active: 1, visibleOffline: 0, hidden: 0, flooding: 0, nearFlooding: 0 });
+  });
+});
+
+describe("computeStubChanges", () => {
+  const loc = (id: string, isMetagage = false) => ({ id, isMetagage });
+  const real = (locationId: string) => ({ locationId, _isStub: false });
+  const stub = (locationId: string) => ({ locationId, _isStub: true });
+
+  it("removes all stubs when showHidden is false", () => {
+    expect(
+      computeStubChanges({
+        gages: [real("A"), stub("B"), stub("C")],
+        locationInfos: [loc("A"), loc("B"), loc("C")],
+        showHidden: false,
+      })
+    ).toEqual({ toAdd: [], toRemove: ["B", "C"] });
+  });
+
+  it("adds stubs for hidden locations when showHidden is true", () => {
+    expect(
+      computeStubChanges({
+        gages: [real("A")],
+        locationInfos: [loc("A"), loc("B"), loc("C")],
+        showHidden: true,
+      })
+    ).toEqual({ toAdd: ["B", "C"], toRemove: [] });
+  });
+
+  it("removes stale stubs whose locationId is now in real gages", () => {
+    expect(
+      computeStubChanges({
+        gages: [real("A"), stub("A")],
+        locationInfos: [loc("A")],
+        showHidden: true,
+      })
+    ).toEqual({ toAdd: [], toRemove: ["A"] });
+  });
+
+  it("skips metagage locations when building stubs", () => {
+    expect(
+      computeStubChanges({
+        gages: [],
+        locationInfos: [loc("A"), loc("META/AGE", true)],
+        showHidden: true,
+      })
+    ).toEqual({ toAdd: ["A"], toRemove: [] });
+  });
+
+  it("is idempotent — second call with the synced result produces no changes", () => {
+    const first = computeStubChanges({
+      gages: [real("A")],
+      locationInfos: [loc("A"), loc("B")],
+      showHidden: true,
+    });
+    expect(first).toEqual({ toAdd: ["B"], toRemove: [] });
+
+    const synced = [real("A"), stub("B")];
+    const second = computeStubChanges({
+      gages: synced,
+      locationInfos: [loc("A"), loc("B")],
+      showHidden: true,
+    });
+    expect(second).toEqual({ toAdd: [], toRemove: [] });
+  });
+});
+
+describe("makeStubSnapshot", () => {
+  it("returns a minimal snapshot suitable for GageStore.gages.push", () => {
+    expect(makeStubSnapshot("USGS-23")).toEqual({
+      locationId: "USGS-23",
+      locationInfo: "USGS-23",
+      isOffline: true,
+      _isStub: true,
+    });
   });
 });

--- a/src/models/helpers/__tests__/regionSummary.test.ts
+++ b/src/models/helpers/__tests__/regionSummary.test.ts
@@ -1,4 +1,4 @@
-import { computeForecastSeverity } from "../regionSummary";
+import { computeForecastSeverity, computeBucketCounts } from "../regionSummary";
 
 describe("computeForecastSeverity", () => {
   it("returns 'none' for an empty input", () => {
@@ -57,5 +57,73 @@ describe("computeForecastSeverity", () => {
         { peaks: [{ waterDischarge: 9999 }], dischargeStageOne: 0, dischargeStageTwo: 0 },
       ])
     ).toBe("none");
+  });
+});
+
+describe("computeBucketCounts", () => {
+  const loc = (id: string, isMetagage = false) => ({ id, isMetagage });
+  const gage = (locationId: string, floodLevel = "Normal", isStub = false) => ({
+    locationId,
+    _isStub: isStub,
+    gageStatus: { floodLevel },
+  });
+
+  it("counts a fleet of all-normal gauges as fully active", () => {
+    expect(
+      computeBucketCounts({
+        gages: [gage("A"), gage("B")],
+        locationInfos: [loc("A"), loc("B")],
+      })
+    ).toEqual({ active: 2, visibleOffline: 0, hidden: 0, flooding: 0, nearFlooding: 0 });
+  });
+
+  it("separates active / visible-offline by floodLevel", () => {
+    expect(
+      computeBucketCounts({
+        gages: [gage("A", "Normal"), gage("B", "Offline"), gage("C", "Flooding")],
+        locationInfos: [loc("A"), loc("B"), loc("C")],
+      })
+    ).toEqual({ active: 2, visibleOffline: 1, hidden: 0, flooding: 1, nearFlooding: 0 });
+  });
+
+  it("counts flooding and nearFlooding levels", () => {
+    expect(
+      computeBucketCounts({
+        gages: [
+          gage("A", "Flooding"),
+          gage("B", "Flooding"),
+          gage("C", "NearFlooding"),
+          gage("D", "Normal"),
+        ],
+        locationInfos: [loc("A"), loc("B"), loc("C"), loc("D")],
+      })
+    ).toEqual({ active: 4, visibleOffline: 0, hidden: 0, flooding: 2, nearFlooding: 1 });
+  });
+
+  it("counts hidden locations (in locationInfos but not in gages)", () => {
+    expect(
+      computeBucketCounts({
+        gages: [gage("A")],
+        locationInfos: [loc("A"), loc("B"), loc("C")],
+      })
+    ).toEqual({ active: 1, visibleOffline: 0, hidden: 2, flooding: 0, nearFlooding: 0 });
+  });
+
+  it("excludes stubs from active / visible-offline / flood counts", () => {
+    expect(
+      computeBucketCounts({
+        gages: [gage("A", "Normal"), gage("B", "Flooding", /* isStub */ true)],
+        locationInfos: [loc("A"), loc("B")],
+      })
+    ).toEqual({ active: 1, visibleOffline: 0, hidden: 1, flooding: 0, nearFlooding: 0 });
+  });
+
+  it("excludes metagages from the hidden count", () => {
+    expect(
+      computeBucketCounts({
+        gages: [gage("A")],
+        locationInfos: [loc("A"), loc("META/AGE", true)],
+      })
+    ).toEqual({ active: 1, visibleOffline: 0, hidden: 0, flooding: 0, nearFlooding: 0 });
   });
 });

--- a/src/models/helpers/regionSummary.ts
+++ b/src/models/helpers/regionSummary.ts
@@ -25,3 +25,60 @@ export function computeForecastSeverity(forecasts: ForecastSeverityInput[]): For
   }
   return hasNear ? "near" : "none";
 }
+
+export interface BucketCountsInput {
+  gages: readonly {
+    locationId?: string;
+    _isStub?: boolean;
+    gageStatus?: { floodLevel?: string };
+  }[];
+  locationInfos: readonly { id: string; isMetagage?: boolean }[];
+}
+
+export interface BucketCounts {
+  active: number;
+  visibleOffline: number;
+  hidden: number;
+  flooding: number;
+  nearFlooding: number;
+}
+
+export function computeBucketCounts({ gages, locationInfos }: BucketCountsInput): BucketCounts {
+  let active = 0;
+  let visibleOffline = 0;
+  let flooding = 0;
+  let nearFlooding = 0;
+  const realGageIds = new Set<string>();
+
+  for (const g of gages) {
+    if (g._isStub) {
+      continue;
+    }
+    if (g.locationId) {
+      realGageIds.add(g.locationId);
+    }
+    const level = g.gageStatus?.floodLevel;
+    if (level === "Offline") {
+      visibleOffline++;
+    } else {
+      active++;
+    }
+    if (level === "Flooding") {
+      flooding++;
+    } else if (level === "NearFlooding") {
+      nearFlooding++;
+    }
+  }
+
+  let hidden = 0;
+  for (const l of locationInfos) {
+    if (l.isMetagage) {
+      continue;
+    }
+    if (!realGageIds.has(l.id)) {
+      hidden++;
+    }
+  }
+
+  return { active, visibleOffline, hidden, flooding, nearFlooding };
+}

--- a/src/models/helpers/regionSummary.ts
+++ b/src/models/helpers/regionSummary.ts
@@ -138,23 +138,12 @@ export function computeStubChanges({
   return { toAdd, toRemove };
 }
 
-/**
- * Snapshot shape used to push a stub gage into GageStore.gages.
- *
- * The explicit empty arrays for readings/actualReadings/predictions force MST to
- * materialize the backing MobX observables during the action's init phase. Without
- * them, the first read of `stub.readings` (typically by React DevTools during the
- * commit phase) tries to lazy-init outside an action context and throws
- * "the creation of the observable instance must be done on the initializing phase".
- */
+/** Snapshot shape used to push a stub gage into GageStore.gages. */
 export function makeStubSnapshot(locationId: string) {
   return {
     locationId,
     locationInfo: locationId,
     isOffline: true,
     _isStub: true,
-    readings: [],
-    actualReadings: [],
-    predictions: [],
   };
 }

--- a/src/models/helpers/regionSummary.ts
+++ b/src/models/helpers/regionSummary.ts
@@ -1,4 +1,8 @@
-export type ForecastSeverity = "none" | "near" | "flood";
+export enum ForecastSeverity {
+  None = "none",
+  Near = "near",
+  Flood = "flood",
+}
 
 export interface ForecastSeverityInput {
   peaks?: { waterDischarge?: number | null }[];
@@ -16,14 +20,14 @@ export function computeForecastSeverity(forecasts: ForecastSeverityInput[]): For
         continue;
       }
       if (dischargeStageTwo && q >= dischargeStageTwo) {
-        return "flood";
+        return ForecastSeverity.Flood;
       }
       if (dischargeStageOne && q >= dischargeStageOne) {
         hasNear = true;
       }
     }
   }
-  return hasNear ? "near" : "none";
+  return hasNear ? ForecastSeverity.Near : ForecastSeverity.None;
 }
 
 export interface BucketCountsInput {

--- a/src/models/helpers/regionSummary.ts
+++ b/src/models/helpers/regionSummary.ts
@@ -142,12 +142,24 @@ export function computeStubChanges({
   return { toAdd, toRemove };
 }
 
-/** Snapshot shape used to push a stub gage into GageStore.gages. */
+/**
+ * Snapshot shape used to push a stub gage into GageStore.gages.
+ *
+ * The empty arrays are intentional: omitting them lets MST defer materialization of
+ * the `types.array(...)` child observables, which trips MST 7 bug
+ * github.com/mobxjs/mobx-state-tree#2279 under React 19's dev-mode profiler. Passing
+ * `[]` forces MST to materialize the array properties during create (in the legal
+ * init phase) so downstream consumers can hand the MST node to React without the
+ * commit-phase prop traversal poisoning the tree.
+ */
 export function makeStubSnapshot(locationId: string) {
   return {
     locationId,
     locationInfo: locationId,
     isOffline: true,
     _isStub: true,
+    readings: [],
+    actualReadings: [],
+    predictions: [],
   };
 }

--- a/src/models/helpers/regionSummary.ts
+++ b/src/models/helpers/regionSummary.ts
@@ -138,12 +138,23 @@ export function computeStubChanges({
   return { toAdd, toRemove };
 }
 
-/** Snapshot shape used to push a stub gage into GageStore.gages. */
+/**
+ * Snapshot shape used to push a stub gage into GageStore.gages.
+ *
+ * The explicit empty arrays for readings/actualReadings/predictions force MST to
+ * materialize the backing MobX observables during the action's init phase. Without
+ * them, the first read of `stub.readings` (typically by React DevTools during the
+ * commit phase) tries to lazy-init outside an action context and throws
+ * "the creation of the observable instance must be done on the initializing phase".
+ */
 export function makeStubSnapshot(locationId: string) {
   return {
     locationId,
     locationInfo: locationId,
     isOffline: true,
     _isStub: true,
+    readings: [],
+    actualReadings: [],
+    predictions: [],
   };
 }

--- a/src/models/helpers/regionSummary.ts
+++ b/src/models/helpers/regionSummary.ts
@@ -1,0 +1,27 @@
+export type ForecastSeverity = "none" | "near" | "flood";
+
+export interface ForecastSeverityInput {
+  peaks?: { waterDischarge?: number | null }[];
+  dischargeStageOne?: number;
+  dischargeStageTwo?: number;
+}
+
+export function computeForecastSeverity(forecasts: ForecastSeverityInput[]): ForecastSeverity {
+  let hasNear = false;
+  for (const forecast of forecasts) {
+    const { peaks, dischargeStageOne, dischargeStageTwo } = forecast;
+    for (const peak of peaks ?? []) {
+      const q = peak.waterDischarge;
+      if (q == null) {
+        continue;
+      }
+      if (dischargeStageTwo && q >= dischargeStageTwo) {
+        return "flood";
+      }
+      if (dischargeStageOne && q >= dischargeStageOne) {
+        hasNear = true;
+      }
+    }
+  }
+  return hasNear ? "near" : "none";
+}

--- a/src/models/helpers/regionSummary.ts
+++ b/src/models/helpers/regionSummary.ts
@@ -82,3 +82,68 @@ export function computeBucketCounts({ gages, locationInfos }: BucketCountsInput)
 
   return { active, visibleOffline, hidden, flooding, nearFlooding };
 }
+
+export interface StubChangesInput {
+  gages: readonly { locationId?: string; _isStub?: boolean }[];
+  locationInfos: readonly { id: string; isMetagage?: boolean }[];
+  showHidden: boolean;
+}
+
+export interface StubChanges {
+  toAdd: string[];
+  toRemove: string[];
+}
+
+export function computeStubChanges({
+  gages,
+  locationInfos,
+  showHidden,
+}: StubChangesInput): StubChanges {
+  const realGageIds = new Set<string>();
+  const existingStubIds = new Set<string>();
+  for (const g of gages) {
+    if (!g.locationId) {
+      continue;
+    }
+    if (g._isStub) {
+      existingStubIds.add(g.locationId);
+    } else {
+      realGageIds.add(g.locationId);
+    }
+  }
+
+  if (!showHidden) {
+    return { toAdd: [], toRemove: [...existingStubIds] };
+  }
+
+  const wantStubIds = new Set<string>();
+  for (const l of locationInfos) {
+    if (!l.isMetagage && !realGageIds.has(l.id)) {
+      wantStubIds.add(l.id);
+    }
+  }
+
+  const toAdd: string[] = [];
+  for (const id of wantStubIds) {
+    if (!existingStubIds.has(id)) {
+      toAdd.push(id);
+    }
+  }
+  const toRemove: string[] = [];
+  for (const id of existingStubIds) {
+    if (!wantStubIds.has(id)) {
+      toRemove.push(id);
+    }
+  }
+  return { toAdd, toRemove };
+}
+
+/** Snapshot shape used to push a stub gage into GageStore.gages. */
+export function makeStubSnapshot(locationId: string) {
+  return {
+    locationId,
+    locationInfo: locationId,
+    isOffline: true,
+    _isStub: true,
+  };
+}

--- a/src/models/helpers/setupRootStore.ts
+++ b/src/models/helpers/setupRootStore.ts
@@ -37,11 +37,22 @@ export async function setupRootStore(rootStore: RootStore) {
     const loadedState: RootStore =
       (await storage.load(ROOT_STATE_STORAGE_KEY)) || ROOT_STORE_DEFAULT;
 
+    // Strip any stub gauges from the cached state. Stubs are session-scoped and
+    // get re-added by syncHiddenStubs after fetch. Persisting stubs causes a destroy/
+    // recreate cycle when fetchData replaces the array (MST destroys unmatched
+    // identifiers), and React DevTools' commit-phase diff then walks the dead old
+    // stub references, spamming "Path upon death" warnings (non-fatal but noisy).
+    const cachedGagesStore = (loadedState as any)?.gagesStore;
+    const cachedGages: any[] = cachedGagesStore?.gages ?? [];
     restoredState = {
       ...loadedState,
       forecastsStore: {
         ...loadedState.forecastsStore,
         maxReadingId: null,
+      },
+      gagesStore: {
+        ...(cachedGagesStore ?? {}),
+        gages: cachedGages.filter((g) => !g?._isStub),
       },
       isFetched: false,
     };


### PR DESCRIPTION
## Summary
- Adds a **Region Summary card** at the top of the gauge list showing fleet status (flooding / near-flooding / all normal), a forecast-severity pill, active/offline counts, and a `Show hidden` toggle that reveals long-term-offline gauges across the home list, map markers, and upstream/downstream nav.
- Introduces `_isStub` gauges so previously-hidden gauges can be opened from the list and details page without disturbing the real gauge identities in MST — `syncHiddenStubs` mutates the gages array element-by-element via `.push()` / `.remove()`, and stubs are stripped from persisted state on rehydrate to avoid MST destroy/recreate noise.
- Adds a **"No data in selected range"** pill that overlays the chart whenever there are no readings to plot — covers stubs, offline gauges, and historic ranges with no data.

## What's inside

**Models / helpers** (pure + unit-tested)
- `computeForecastSeverity`, `computeBucketCounts`, `computeStubChanges`, `makeStubSnapshot` in `src/models/helpers/regionSummary.ts`
- `GageStore.syncHiddenStubs` action, `_isStub` prop on `Gage`, `fetchDataForGage` handles stub or missing gauges
- `ForecastStore.severity` view; `RootStore.showHiddenOffline` toggle + `setShowHiddenOffline`, bucket-count and hidden-location selectors, toggle-aware up/down nav
- `setupRootStore` filters `_isStub: true` entries out of the cached state on rehydrate

**Components**
- New `RegionSummaryCard`: combined status line, right-aligned forecast pill on both web and mobile, counts row with `# active, # offline (# hidden)` plus the toggle (the hidden parenthetical and the toggle row are both omitted when `hidden === 0`)
- New `HiddenGageItem`: half-height degraded card that matches the normal gauge card styling but shows `OFFLINE / No recent data`
- `GageDetailsChart`: chart now sits in a `position: relative` container with an absolute, non-interactive overlay pill ("No data in selected range") shown when `!gage.hasData`
- `HomeScreen`: mounts the summary card and dispatches list items by `_isStub`; mobile keeps the existing map above the card

**i18n** — new `regionSummary` block and `gageDetailsChart.noDataInRange` key in both `en.ts` and `es.ts`; Spanish strings follow the noun-state pattern (`en inundación`, not `inundando`) and use `tú` register.

**Misc fixes** (along the way)
- Hidden gauges roll into the offline count (they are also offline)
- ForecastPill uses `TouchableOpacity` so `Link asChild` works on native
- Web reload no longer freezes when `showHiddenOffline` was on at last save
- `LARGE_LABEL_COLORS` is now exported so the summary card can reuse the existing label palette

## Screenshots
<img width="941" height="540" alt="image" src="https://github.com/user-attachments/assets/db318153-6b1e-46f4-91e3-dc76b05db799" />
<img width="334" height="584" alt="image" src="https://github.com/user-attachments/assets/2792a84b-4e31-427c-a9d4-010995298df7" />
<img width="333" height="539" alt="image" src="https://github.com/user-attachments/assets/2f1b001d-3384-4160-a511-2aa16d49d262" />
<img width="334" height="611" alt="image" src="https://github.com/user-attachments/assets/34820f96-e95e-4a8c-a527-22d04d07feca" />
<img width="378" height="709" alt="image" src="https://github.com/user-attachments/assets/112ff0f2-eec9-41cd-a2e5-51ea96511548" />


## Test plan
- [ ] Calm scenario: card shows `All gauges normal` + green forecast pill + accurate counts; toggle row hidden when no hidden gauges. Forecast pill links to Forecast tab.
- [ ] Flood / near-flood scenarios: status line and pill colors match severity
- [ ] Toggle on: hidden gauges appear in list as degraded cards in correct order; map shows them; up/down chevrons walk through them; toggle persists across navigation within the session
- [ ] Hidden gauge details page: "No data in selected range" overlay appears; picking a historical event populates the chart and the overlay disappears
- [ ] Same "no data" overlay shows on any real gauge when the selected range has no readings
- [ ] Timezone round-trip on a stub gauge: pick a historical day range, x-axis ticks match gauge tz, not device tz
- [ ] Cold reload (web): with hidden toggle on. No MST "Path upon death" warnings or errors. Site continues to work.
- [ ] Mobile: smooth list scroll from cold start; summary card sits between map and list
