### PR TITLE
add lint warn rules for 'any' and 'unknown'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,3 @@ docs
 
 expo-env.d.ts
 # @end expo-cli
-
-
-.github/
-AGENTS.md
-DELEGATION_PROTOCOL.md

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ docs
 
 expo-env.d.ts
 # @end expo-cli
+
+
+.github/
+AGENTS.md
+DELEGATION_PROTOCOL.md

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,19 @@ module.exports = defineConfig([
     },
   },
   {
+    files: ["**/*.ts", "**/*.tsx"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "warn",
+      "no-restricted-syntax": [
+        "warn",
+        {
+          selector: "TSUnknownKeyword",
+          message: "Prefer a more specific type instead of `unknown`.",
+        },
+      ],
+    },
+  },
+  {
     ignores: ["node_modules/", "dist/", ".expo/", "ios/", "android/", "patches/"],
   },
 ]);


### PR DESCRIPTION
Thoughts on these lint rules? I just added a warning for now. 

I would like to work through the 'any' types first to get shapes for them. If this lint rule gets approved is there any priority as to where I should start?

Also, would your rather have my .github folder and agentic configuration in the repo or does that matter? I just added them in the gitignore for now.