### PR TITLE
added showDeletedReadings and debug flag plumbing plus some clean up

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Slot } from "expo-router";
+import { Slot, useGlobalSearchParams } from "expo-router";
 import { useFonts } from "expo-font";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
@@ -15,6 +15,7 @@ import { AssetsProvider, useAppAssets } from "@common-ui/contexts/AssetsContext"
 import { isWeb } from "@common-ui/utils/responsive";
 import { GoogleAuthProvider } from "@common-ui/contexts/GoogleAuthContext";
 import { LocaleProvider, useLocale } from "@common-ui/contexts/LocaleContext";
+import { applyDebugFlagsFromParams } from "@utils/debugFlags";
 import { initSentry } from "@utils/sentry";
 import { If } from "@common-ui/components/Conditional";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
@@ -114,6 +115,11 @@ export default function AppLayout() {
 function App() {
   const { getAsset } = useAppAssets();
   const { t } = useLocale();
+  const params = useGlobalSearchParams();
+
+  useEffect(() => {
+    applyDebugFlagsFromParams(params as Record<string, string | string[] | undefined>);
+  }, [params]);
 
   return (
     <>

--- a/src/components/GageDetailsChart.tsx
+++ b/src/components/GageDetailsChart.tsx
@@ -584,7 +584,7 @@ export const GageDetailsChart = observer(function GageDetailsChart(props: GageDe
         </Cell>
         <View style={$chartContainer}>
           <Charts options={chartOptions} />
-          {!gage?.hasData && (
+          {!gage?.hasData && !gagesStore.isFetching && (
             <View pointerEvents="none" style={$noDataOverlay}>
               <View style={$noDataPill}>
                 <RegularText color={Colors.lightDark}>

--- a/src/components/__tests__/GageDetailsChart.slot-interval.test.tsx
+++ b/src/components/__tests__/GageDetailsChart.slot-interval.test.tsx
@@ -33,7 +33,6 @@ jest.mock("@common-ui/contexts/DatePickerContext", () => ({
 
 jest.mock("@services/highcharts/LocalHighchartsReact", () => () => null);
 jest.mock("@services/highcharts/HighchartsReactNative", () => () => null);
-jest.mock("../GageDetailsChartNative", () => ({ GageDetailsChartNative: () => null }));
 jest.mock("@utils/useGageChartOptions", () => ({ __esModule: true, default: () => [{}, null] }));
 
 // Capture useInterval calls so we can assert what delay it was passed.

--- a/src/models/helpers/setupRootStore.ts
+++ b/src/models/helpers/setupRootStore.ts
@@ -12,6 +12,7 @@
 import { applySnapshot, IDisposer, onSnapshot } from "mobx-state-tree";
 import type { RootStore } from "../RootStore";
 import * as storage from "@utils/storage";
+import { loadDebugFlags } from "@utils/debugFlags";
 import { api } from "@services/api";
 import { changeLocale } from "@i18n/i18n";
 import localDayJs from "@services/localDayJs";
@@ -31,6 +32,8 @@ export const ROOT_STORE_DEFAULT = {
 let _disposer: IDisposer;
 export async function setupRootStore(rootStore: RootStore) {
   let restoredState: Record<string, unknown> = {};
+
+  await loadDebugFlags();
 
   try {
     // load the last known state from AsyncStorage

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -7,7 +7,7 @@
  */
 import { ApiResponse, ApisauceInstance, create } from "apisauce";
 import Config from "@config/config";
-import { getDebugFlag } from "@utils/debugFlags";
+import { DebugFlag, getDebugFlag } from "@utils/debugFlags";
 import { GeneralApiProblem, getGeneralApiProblem } from "./apiProblem";
 
 interface ApiConfig {
@@ -268,7 +268,7 @@ export class Api {
       params["includePredictions"] = includePredictions;
     }
 
-    if (getDebugFlag("showDeletedReadings")) {
+    if (getDebugFlag(DebugFlag.ShowDeletedReadings)) {
       params["showDeletedReadings"] = true;
     }
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -7,6 +7,7 @@
  */
 import { ApiResponse, ApisauceInstance, create } from "apisauce";
 import Config from "@config/config";
+import { getDebugFlag } from "@utils/debugFlags";
 import { GeneralApiProblem, getGeneralApiProblem } from "./apiProblem";
 
 interface ApiConfig {
@@ -265,6 +266,10 @@ export class Api {
 
     if (includePredictions) {
       params["includePredictions"] = includePredictions;
+    }
+
+    if (getDebugFlag("showDeletedReadings")) {
+      params["showDeletedReadings"] = true;
     }
 
     return await genericGetRequest<T>(this.apisauce, Config.API.reading.GET_READINGS_URL, params);

--- a/src/utils/debugFlags.ts
+++ b/src/utils/debugFlags.ts
@@ -1,0 +1,104 @@
+/**
+ * Lightweight, persisted debug flags for power users (data managers, devs).
+ *
+ * Flags are toggled via URL params (e.g. `?debug=showDeletedReadings`),
+ * persisted to AsyncStorage with a TTL, and read synchronously from API
+ * code via getDebugFlag(). Not user-facing UX — intentionally undocumented.
+ *
+ * URL grammar:
+ *   ?debug=showDeletedReadings           enable one flag
+ *   ?debug=showDeletedReadings,otherFlag enable multiple
+ *   ?debug=reset                         clear all flags
+ */
+import * as storage from "./storage";
+
+const STORAGE_KEY = "debug-flags-v1";
+const TTL_MS = 24 * 60 * 60 * 1000; // 1 day
+
+const URL_PARAM = "debug";
+const RESET_TOKEN = "reset";
+
+export type DebugFlagName = "showDeletedReadings";
+
+const VALID_FLAGS: readonly DebugFlagName[] = ["showDeletedReadings"] as const;
+
+type StoredShape = {
+  flags: Partial<Record<DebugFlagName, boolean>>;
+  expiresAt: number;
+};
+
+let cached: Partial<Record<DebugFlagName, boolean>> = {};
+
+export function getDebugFlag(name: DebugFlagName): boolean {
+  return !!cached[name];
+}
+
+export async function loadDebugFlags(): Promise<void> {
+  const stored = (await storage.load(STORAGE_KEY)) as StoredShape | null;
+  if (!stored || typeof stored !== "object") {
+    return;
+  }
+  if (!stored.expiresAt || stored.expiresAt < Date.now()) {
+    await storage.remove(STORAGE_KEY);
+    return;
+  }
+  cached = stored.flags ?? {};
+}
+
+async function persist(): Promise<void> {
+  if (Object.keys(cached).length === 0) {
+    await storage.remove(STORAGE_KEY);
+    return;
+  }
+  const payload: StoredShape = {
+    flags: cached,
+    expiresAt: Date.now() + TTL_MS,
+  };
+  await storage.save(STORAGE_KEY, payload);
+}
+
+export async function resetDebugFlags(): Promise<void> {
+  cached = {};
+  await storage.remove(STORAGE_KEY);
+}
+
+function isValidFlag(value: string): value is DebugFlagName {
+  return (VALID_FLAGS as readonly string[]).includes(value);
+}
+
+export async function applyDebugFlagsFromParams(
+  params: Record<string, string | string[] | undefined>
+): Promise<void> {
+  const raw = params[URL_PARAM];
+  if (raw === undefined || raw === null) {
+    return;
+  }
+  const tokens = (Array.isArray(raw) ? raw : [raw])
+    .flatMap((s) => String(s).split(","))
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (tokens.length === 0) {
+    return;
+  }
+  if (tokens.includes(RESET_TOKEN)) {
+    await resetDebugFlags();
+    return;
+  }
+
+  let changed = false;
+  for (const token of tokens) {
+    if (isValidFlag(token) && !cached[token]) {
+      cached[token] = true;
+      changed = true;
+    }
+  }
+  if (changed) {
+    await persist();
+  } else {
+    // No new flag changes, but the user re-visited the URL — bump TTL.
+    if (Object.keys(cached).length > 0) {
+      await persist();
+    }
+  }
+}

--- a/src/utils/debugFlags.ts
+++ b/src/utils/debugFlags.ts
@@ -18,18 +18,21 @@ const TTL_MS = 24 * 60 * 60 * 1000; // 1 day
 const URL_PARAM = "debug";
 const RESET_TOKEN = "reset";
 
-export type DebugFlagName = "showDeletedReadings";
+export enum DebugFlag {
+  ShowDeletedReadings = "showDeletedReadings",
+}
 
-const VALID_FLAGS: readonly DebugFlagName[] = ["showDeletedReadings"] as const;
+// Derived from the enum — single source of truth for the valid flag set.
+const VALID_FLAGS: readonly string[] = Object.values(DebugFlag);
 
 type StoredShape = {
-  flags: Partial<Record<DebugFlagName, boolean>>;
+  flags: Partial<Record<DebugFlag, boolean>>;
   expiresAt: number;
 };
 
-let cached: Partial<Record<DebugFlagName, boolean>> = {};
+let cached: Partial<Record<DebugFlag, boolean>> = {};
 
-export function getDebugFlag(name: DebugFlagName): boolean {
+export function getDebugFlag(name: DebugFlag): boolean {
   return !!cached[name];
 }
 
@@ -62,8 +65,8 @@ export async function resetDebugFlags(): Promise<void> {
   await storage.remove(STORAGE_KEY);
 }
 
-function isValidFlag(value: string): value is DebugFlagName {
-  return (VALID_FLAGS as readonly string[]).includes(value);
+function isValidFlag(value: string): value is DebugFlag {
+  return VALID_FLAGS.includes(value);
 }
 
 export async function applyDebugFlagsFromParams(

--- a/src/utils/useGageChartOptions.ts
+++ b/src/utils/useGageChartOptions.ts
@@ -306,7 +306,8 @@ function createSeriesAndReturnMin(
   color,
   setIsPrediction,
   chartDataType,
-  tz: string
+  tz: string,
+  hideLine: boolean = false
 ) {
   let data = null;
   let min = Math.min.apply(
@@ -409,12 +410,12 @@ function createSeriesAndReturnMin(
     color: color,
     fillOpacity: 0.5,
     threshold: gage?.groundHeight,
-    lineWidth: 2,
+    lineWidth: hideLine ? 0 : 2,
     gapUnit: "value",
     gapSize: localDayJs.duration(2, "hours").asMilliseconds(),
     states: {
       hover: {
-        lineWidth: 3,
+        lineWidth: hideLine ? 0 : 3,
       },
     },
     marker: {
@@ -503,13 +504,14 @@ function createDataAndReturnMin(gage: Gage, chartDataType: GageChartDataType, t,
 
   if (deletedReadings.length > 0) {
     const [deletedReadingsSeries, deletedSeriesMin] = createSeriesAndReturnMin(
-      dataPoints,
+      deletedReadings,
       gage,
       t,
       Colors.gageChartDeletedLineColor,
       false,
       chartDataType,
-      tz
+      tz,
+      true
     );
     chartData.push(...deletedReadingsSeries);
     min = Math.min(seriesMin, deletedSeriesMin);


### PR DESCRIPTION
## Summary

Adds a `showDeletedReadings` debug flag for data managers to view readings that have been soft-deleted on the backend, plus related fixes uncovered while building it.

### Debug flag plumbing
- New `src/utils/debugFlags.ts` — persisted (24h TTL), URL-toggleable flag store. Enable via `?debug=showDeletedReadings`, combine with `?debug=flagA,flagB`, clear with `?debug=reset`.
- `app/_layout.tsx` reads global search params on mount and applies them via `applyDebugFlagsFromParams`.
- `setupRootStore.ts` calls `loadDebugFlags()` on startup so the flag is available before the first API request.
- `api.ts` appends `showDeletedReadings=true` to `GET_READINGS_URL` when the flag is set.

### Chart rendering fixes
- `GageDetailsChart.tsx`: suppress the "no data" overlay while a fetch is in flight, so it doesn't flash on initial load.
- `useGageChartOptions.ts`: deleted-readings series was being built from `dataPoints` (all readings) instead of `deletedReadings` — corrected the source array. Added a `hideLine` option so the deleted series renders as markers only (no connecting line), distinguishing deletions from actual readings.

### Test fix
- `GageDetailsChart.slot-interval.test.tsx`: removed a stale `jest.mock("../GageDetailsChartNative", ...)` — that file was deleted in 164234b (orphaned Victory chart cleanup) and the mock was preventing the suite from loading.

## Test plan

- [ ] `npm test` passes (including the previously broken slot-interval suite)
- [ ] `npx tsc --noEmit` clean
- [ ] Load app with `?debug=showDeletedReadings`, confirm `GET_READINGS_URL` requests include `showDeletedReadings=true` (devtools / network panel)
- [ ] Confirm deleted readings render as markers (no connecting line) on the gauge detail chart, in the deleted-line color
- [ ] Reload without the param within 24h — flag still active (persistence works)
- [ ] Wait >24h or use `?debug=reset` — flag cleared
- [ ] Initial load on a slow connection: no "no data" overlay flashes before readings arrive
