### PR TITLE
Fix/deep link hidden gauge

### DIFF
--- a/app/(root)/gage/[id].tsx
+++ b/app/(root)/gage/[id].tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { TouchableOpacity } from "react-native";
 import { ErrorBoundaryProps, Link, Stack, useLocalSearchParams } from "expo-router";
 import Head from "expo-router/head";
@@ -300,8 +300,19 @@ const GageScreen = observer(function GageScreen() {
   const { id } = useLocalSearchParams();
   const { t } = useLocale();
   const store = useStores();
+  const { isHiddenLocation, setShowHiddenOffline, showHiddenOffline } = store;
 
   const gageId = Array.isArray(id) ? id.join("/") : id;
+
+  // Deep-linking to a hidden gauge with the toggle off would otherwise pin the
+  // screen on EmptyComponent forever — the id never appears in
+  // getLocationWithGagesIds(). Flip the toggle on (which syncs stubs) so the next
+  // render resolves an initialIndex.
+  useEffect(() => {
+    if (!showHiddenOffline && gageId && isHiddenLocation(gageId)) {
+      setShowHiddenOffline(true);
+    }
+  }, [gageId, showHiddenOffline, isHiddenLocation, setShowHiddenOffline]);
 
   const [hidden, setHidden] = useState(isMobile ? true : false);
 

--- a/src/components/__tests__/GageScreen.autoToggle.test.tsx
+++ b/src/components/__tests__/GageScreen.autoToggle.test.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+// Import after mocks are set up. Use a RELATIVE path: the jest config maps only the
+// `@<alias>/*` paths and there is no `roots`/`moduleDirectories` entry for the project
+// root, so a bare `app/...` specifier will NOT resolve.
+import GageScreen from "../../../app/(root)/gage/[id]";
+
+const setShowHiddenOffline = jest.fn();
+const mockUseLocalSearchParams = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => mockUseLocalSearchParams(),
+  Link: ({ children }: any) => children,
+  Stack: { Screen: () => null },
+  useRouter: () => ({ setParams: jest.fn(), push: jest.fn(), back: jest.fn() }),
+}));
+
+jest.mock("expo-router/head", () => ({
+  __esModule: true,
+  default: ({ children }: any) => children,
+}));
+
+// Minimal stub store; only the fields GageScreen reads.
+const buildMockStores = (overrides: Partial<any> = {}) => ({
+  setShowHiddenOffline,
+  showHiddenOffline: false,
+  isHiddenLocation: jest.fn().mockReturnValue(false),
+  getLocationWithGagesIds: jest.fn().mockReturnValue([]),
+  gagesStore: { getGageByLocationId: jest.fn(), fetchData: jest.fn() },
+  regionStore: { region: null },
+  ...overrides,
+});
+
+let mockStores: ReturnType<typeof buildMockStores>;
+
+jest.mock("@models/helpers/useStores", () => ({
+  useStores: () => mockStores,
+}));
+
+jest.mock("@common-ui/contexts/LocaleContext", () => ({
+  useLocale: () => ({ t: (k: string) => k }),
+}));
+
+// The screen renders heavy children (charts, maps). Stub them so the test stays
+// focused on the auto-toggle behavior.
+jest.mock("@components/ChainPager", () => ({
+  ChainPager: () => null,
+  ChainPagerContext: { Provider: ({ children }: any) => children },
+}));
+jest.mock("@common-ui/components/EmptyComponent", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+// Additional mocks needed to prevent module load failures from heavy imports
+jest.mock("mobx-react-lite", () => ({
+  observer: (fn: any) => fn,
+}));
+
+jest.mock("@utils/useTimeout", () => ({
+  useTimeout: jest.fn(),
+}));
+
+jest.mock("@utils/useGoBack", () => ({
+  useGoBack: () => jest.fn(),
+}));
+
+jest.mock("@common-ui/utils/responsive", () => ({
+  isWeb: false,
+  isMobile: true,
+  useResponsive: () => ({ isMobile: true }),
+  MobileScreen: ({ children }: any) => children,
+  WideScreen: () => null,
+}));
+
+jest.mock("@components/GageDetailsChart", () => ({
+  GageDetailsChart: () => null,
+}));
+
+jest.mock("@components/CalloutReadingCard", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@components/GageImageCard", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@components/GageInfoCard", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@components/StatusLevelsCard", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@components/GageMap", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@components/ErrorDetails", () => ({
+  ErrorDetails: () => null,
+}));
+
+jest.mock("@common-ui/components/Button", () => ({
+  IconButton: () => null,
+  LinkButton: () => null,
+}));
+
+jest.mock("@common-ui/components/Label", () => ({
+  Label: () => null,
+}));
+
+jest.mock("app/_layout", () => ({
+  ROUTES: {
+    GageDetails: "/gage/[id]",
+    Home: "/",
+  },
+}));
+
+describe("GageScreen auto-toggle on hidden gauge deep link", () => {
+  beforeEach(() => {
+    setShowHiddenOffline.mockReset();
+    mockUseLocalSearchParams.mockReturnValue({ id: "SVPA-29" });
+  });
+
+  it("enables showHiddenOffline when URL targets a hidden gauge", () => {
+    mockStores = buildMockStores({
+      isHiddenLocation: jest.fn((id: string) => id === "SVPA-29"),
+      getLocationWithGagesIds: jest.fn().mockReturnValue(["USGS-38", "USGS-22"]),
+    });
+
+    render(<GageScreen />);
+
+    expect(mockStores.isHiddenLocation).toHaveBeenCalledWith("SVPA-29");
+    expect(setShowHiddenOffline).toHaveBeenCalledWith(true);
+  });
+
+  it("does NOT toggle when URL targets a visible gauge", () => {
+    mockStores = buildMockStores({
+      isHiddenLocation: jest.fn().mockReturnValue(false),
+      getLocationWithGagesIds: jest.fn().mockReturnValue(["USGS-38", "USGS-22"]),
+    });
+    mockUseLocalSearchParams.mockReturnValue({ id: "USGS-22" });
+
+    render(<GageScreen />);
+
+    expect(setShowHiddenOffline).not.toHaveBeenCalled();
+  });
+
+  it("does NOT toggle when URL targets an unknown gauge", () => {
+    mockStores = buildMockStores({
+      isHiddenLocation: jest.fn().mockReturnValue(false), // unknown → not hidden
+      getLocationWithGagesIds: jest.fn().mockReturnValue(["USGS-38", "USGS-22"]),
+    });
+    mockUseLocalSearchParams.mockReturnValue({ id: "USGS-9999" });
+
+    render(<GageScreen />);
+
+    expect(setShowHiddenOffline).not.toHaveBeenCalled();
+  });
+});

--- a/src/models/RootStore.ts
+++ b/src/models/RootStore.ts
@@ -115,6 +115,18 @@ export const RootStoreModel = types
       return realLocations().filter((l) => !realGageIds.has(l.id));
     };
 
+    // A location is "hidden" for deep-link purposes only if (a) it is a stub-eligible
+    // hidden location — i.e. a real, non-metagage location with no backing gage, which
+    // `hiddenLocations()` already computes — and (b) it is not currently in the visible
+    // list. Reusing hiddenLocations() (rather than scanning all locationInfos) excludes
+    // the synthetic metagage, for which no stub is ever created; flipping the toggle on
+    // for it would never reveal it. When the toggle is on, the stub is present and the id
+    // appears in getLocationWithGagesIds(), so this correctly returns false.
+    const isHiddenLocation = (locationId: string) =>
+      !!locationId &&
+      hiddenLocations().some((l) => l.id === locationId) &&
+      !getLocationWithGagesIds().includes(locationId);
+
     const getBucketCounts = () =>
       computeBucketCounts({
         gages: store.gagesStore.gages,
@@ -153,6 +165,7 @@ export const RootStoreModel = types
       getTimezone,
       getLocationsWithGages,
       getLocationWithGagesIds,
+      isHiddenLocation,
       getUpstreamGageLocation,
       getDownstreamGageLocation,
       realLocations,

--- a/src/models/__tests__/RootStore.isHiddenLocation.test.ts
+++ b/src/models/__tests__/RootStore.isHiddenLocation.test.ts
@@ -1,0 +1,68 @@
+import { RootStoreModel } from "@models/RootStore";
+
+describe("RootStore.isHiddenLocation", () => {
+  const buildStore = (showHiddenOffline: boolean) =>
+    RootStoreModel.create({
+      showHiddenOffline,
+      locationInfoStore: {
+        locationInfos: [
+          { id: "USGS-38" },
+          { id: "SVPA-29" }, // hidden when toggle off
+          { id: "USGS-22" },
+        ] as any,
+      },
+      gagesStore: {
+        gages: [
+          { locationId: "USGS-38", _isStub: false },
+          { locationId: "USGS-22", _isStub: false },
+        ] as any,
+      },
+    });
+
+  it("returns true for a known location not currently in getLocationWithGagesIds", () => {
+    const store = buildStore(false);
+    expect(store.isHiddenLocation("SVPA-29")).toBe(true);
+  });
+
+  it("returns false for a location that is already visible", () => {
+    const store = buildStore(false);
+    expect(store.isHiddenLocation("USGS-22")).toBe(false);
+  });
+
+  it("returns false for an unknown locationId — caller should still render empty state", () => {
+    const store = buildStore(false);
+    expect(store.isHiddenLocation("USGS-9999")).toBe(false);
+  });
+
+  it("returns false once the toggle is on and the location is included", () => {
+    const store = buildStore(false);
+    // Use the action (not create()) so syncHiddenStubs actually runs: it adds the
+    // SVPA-29 stub, which then appears in getLocationWithGagesIds() — so the
+    // !includes(...) clause is what makes this correctly return false.
+    store.setShowHiddenOffline(true);
+    expect(store.isHiddenLocation("SVPA-29")).toBe(false);
+  });
+
+  it("returns false for a metagage location with no backing gage (a stub is never created for it)", () => {
+    const store = RootStoreModel.create({
+      showHiddenOffline: false,
+      locationInfoStore: {
+        locationInfos: [
+          { id: "USGS-38" },
+          { id: "META-1", isMetagage: true }, // synthetic, never stubbed
+          { id: "USGS-22" },
+        ] as any,
+      },
+      gagesStore: {
+        gages: [
+          { locationId: "USGS-38", _isStub: false },
+          { locationId: "USGS-22", _isStub: false },
+        ] as any,
+      },
+    });
+    // META-1 is known and not visible, but flipping the toggle would never reveal it,
+    // so isHiddenLocation must NOT report it as hidden (otherwise the screen strands on
+    // EmptyComponent and the global toggle gets uselessly turned on).
+    expect(store.isHiddenLocation("META-1")).toBe(false);
+  });
+});

--- a/src/models/helpers/__tests__/setupRootStore.test.ts
+++ b/src/models/helpers/__tests__/setupRootStore.test.ts
@@ -1,0 +1,97 @@
+import { RootStoreModel } from "@models/RootStore";
+import { setupRootStore } from "../setupRootStore";
+
+// Storage layer is mocked so we can hand setupRootStore an exact snapshot.
+jest.mock("@utils/storage", () => ({
+  load: jest.fn(),
+  save: jest.fn().mockResolvedValue(true),
+}));
+
+// setupRootStore calls api.setHeader when an auth token is present. Stub it.
+jest.mock("@services/api", () => ({
+  api: {
+    setHeader: jest.fn(),
+    removeHeader: jest.fn(),
+  },
+}));
+
+// Locale plumbing — irrelevant to this test but imported by setupRootStore.
+// AuthSession.ts also imports { i18n } and reads i18n.locale at model-definition time.
+jest.mock("@i18n/i18n", () => ({ changeLocale: jest.fn(), i18n: { locale: "en" } }));
+jest.mock("@services/localDayJs", () => ({
+  __esModule: true,
+  default: { locale: jest.fn() },
+}));
+
+const { load } = jest.requireMock("@utils/storage") as { load: jest.Mock };
+
+describe("setupRootStore stub rehydration", () => {
+  beforeEach(() => {
+    load.mockReset();
+  });
+
+  it("repopulates stubs for hidden locations when showHiddenOffline rehydrates as true", async () => {
+    // Snapshot mimicking a session that ended with the toggle ON. Stubs were stripped
+    // during persist (postProcessSnapshot), so only real gauges are present.
+    load.mockResolvedValueOnce({
+      isFetched: false,
+      showHiddenOffline: true,
+      gagesStore: {
+        gages: [
+          { locationId: "USGS-38", _isStub: false },
+          { locationId: "USGS-22", _isStub: false },
+        ],
+      },
+      locationInfoStore: {
+        locationInfos: [
+          { id: "USGS-38" },
+          { id: "SVPA-29" }, // hidden — no corresponding real gauge
+          { id: "USGS-22" },
+          { id: "SVPA-25" }, // hidden — no corresponding real gauge
+        ],
+      },
+    });
+
+    const rootStore = RootStoreModel.create({});
+    await setupRootStore(rootStore);
+
+    const locationIds = rootStore.gagesStore.gages.map((g) => g.locationId).sort();
+    expect(locationIds).toEqual(["SVPA-25", "SVPA-29", "USGS-22", "USGS-38"]);
+
+    const svpa29 = rootStore.gagesStore.gages.find((g) => g.locationId === "SVPA-29");
+    expect(svpa29?._isStub).toBe(true);
+
+    // The list the gauge details screen consumes — must include hidden locations
+    // in locationInfos order, so initialIndex doesn't shift after fetchData runs.
+    expect(rootStore.getLocationWithGagesIds()).toEqual([
+      "USGS-38",
+      "SVPA-29",
+      "USGS-22",
+      "SVPA-25",
+    ]);
+  });
+
+  it("does not add stubs when showHiddenOffline rehydrates as false", async () => {
+    load.mockResolvedValueOnce({
+      isFetched: false,
+      showHiddenOffline: false,
+      gagesStore: {
+        gages: [
+          { locationId: "USGS-38", _isStub: false },
+          { locationId: "USGS-22", _isStub: false },
+        ],
+      },
+      locationInfoStore: {
+        locationInfos: [{ id: "USGS-38" }, { id: "SVPA-29" }, { id: "USGS-22" }],
+      },
+    });
+
+    const rootStore = RootStoreModel.create({});
+    await setupRootStore(rootStore);
+
+    expect(rootStore.gagesStore.gages.map((g) => g.locationId).sort()).toEqual([
+      "USGS-22",
+      "USGS-38",
+    ]);
+  });
+});

--- a/src/models/helpers/setupRootStore.ts
+++ b/src/models/helpers/setupRootStore.ts
@@ -71,6 +71,20 @@ export async function setupRootStore(rootStore: RootStore) {
     }
 
     applySnapshot(rootStore, restoredState);
+
+    // Stubs are stripped from the persisted snapshot (see Gage.ts postProcessSnapshot and
+    // the explicit strip in this file), but `showHiddenOffline` IS persisted. Without
+    // re-syncing, a session that ended with the toggle ON resumes with the toggle ON but
+    // no stubs — `getLocationWithGagesIds()` returns a short list until fetchData re-syncs,
+    // which causes the gauge details ChainPager to mount with an initialIndex that shifts
+    // under it once stubs arrive. Route this through setShowHiddenOffline (the single
+    // toggle↔stubs invariant point) rather than calling syncHiddenStubs directly; the value
+    // is already true, so this is idempotent. This runs before the onSnapshot subscription
+    // below, so the re-added stubs are not persisted (and postProcessSnapshot strips them
+    // regardless).
+    if (rootStore.showHiddenOffline) {
+      rootStore.setShowHiddenOffline(true);
+    }
   } catch (e) {
     // if there's any problems loading, then inform the dev what happened
     if (__DEV__) {


### PR DESCRIPTION
# Fix two hidden-gauge deep-link bugs

## Summary

Fixes two related bugs around the **"Show hidden gauges"** toggle (`showHiddenOffline`), both of which made the gauge details screen show the wrong thing when reached via a deep link / page refresh:

1. **Index drift on rehydrate.** When a session ended with the toggle **on**, it resumed with the toggle on but with the session-scoped stub gauges missing (they're stripped from the persisted snapshot). During that window `getLocationWithGagesIds()` returned a short list, so the gauge details `ChainPager` mounted with an `initialIndex` derived from the short list — then the list grew under it once `fetchData` re-added stubs, shifting indices and rendering the **wrong gauge** for any location past the first hidden one.

2. **Permanent loading state on hidden deep link.** Deep-linking to a hidden gauge while the toggle was **off** left the id absent from `getLocationWithGagesIds()`, so `initialIndex === -1` and the screen was pinned on `EmptyComponent` ("loading…") **forever**.

Both are fixed in the MobX State Tree layer, independently.

## Changes

### Fix 1 — Rehydrate stubs when the toggle persists as on
`src/models/helpers/setupRootStore.ts`

After `applySnapshot`, if `showHiddenOffline` rehydrated as `true`, re-establish the toggle↔stubs invariant by calling `rootStore.setShowHiddenOffline(true)` (the single canonical action that keeps the flag and the stub set consistent; idempotent since the value is already true). This runs **before** the `onSnapshot` subscription, so the re-added stubs aren't persisted (and `postProcessSnapshot` strips them regardless).

### Fix 2 — Auto-enable show-hidden when deep-linking to a hidden gauge
`src/models/RootStore.ts`, `app/(root)/gage/[id].tsx`

- New `isHiddenLocation(locationId)` view on `RootStore`. It reuses the existing `hiddenLocations()` view (real, non-metagage locations with no backing gage) rather than scanning all `locationInfos` — this **excludes the synthetic metagage**, which never gets a stub, so we don't strand the screen and uselessly flip the toggle for an id that flipping could never reveal.
- A `useEffect` in `GageScreen` calls `setShowHiddenOffline(true)` when the URL targets a hidden gauge while the toggle is off. The setter already calls `syncHiddenStubs` synchronously, so the gauge appears on the next render. The effect is registered before all early returns (stable hook ordering) and is self-terminating (once the toggle is on, the guard and `isHiddenLocation` both prevent re-firing).

## Deliberate decision: the toggle is persisted

`showHiddenOffline` is a persisted setting, so a hidden-gauge deep link turns "show hidden" on **globally**, and it stays on (the region summary card and gauge nav will then show all hidden gauges until the user turns it back off). This is intentional — the simplest correct fix, and arguably the right behavior since the user explicitly asked to view a hidden gauge. A screen-local "show just this one" override would desync the `ChainPager` pages from the nav list and is materially more complex; if we ever want that, it warrants its own change.

## Known latent issue (out of scope)

`ChainPager` tracks `currentIndex` (a number) rather than `currentKey` (a string), so it can't follow a logical page when the `pages` prop reorders mid-mount. Fix 1 closes the only path in the current codebase that triggers this. Hardening `ChainPager` to track the key is desirable but deferred — flagging it here for whoever next touches that component.

## Test plan

Automated (all green):

- [x] `npm test` — 364 tests pass. New suites: `setupRootStore.test.ts`, `RootStore.isHiddenLocation.test.ts`, `GageScreen.autoToggle.test.tsx`.
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors

> Note: `src/components/__tests__/GageDetailsChart.slot-interval.test.tsx` fails to load (references a non-existent `../GageDetailsChartNative` module). This failure is **pre-existing and unrelated** — it fails identically at this branch's base commit and is untouched by this PR.

Manual matrix (web), toggling "Show hidden" between attempts:

| Toggle initial state | URL gauge | Expected behavior |
|---|---|---|
| OFF | `/gage/USGS-22` (visible) | Loads correctly. Toggle stays OFF. |
| OFF | `/gage/SVPA-29` (hidden) | Brief loading frame, then renders SVPA-29. Toggle is now ON (persisted). |
| ON | `/gage/USGS-38` (visible, upstream of first hidden) | Loads correctly. No flicker. |
| ON | `/gage/USGS-22` (visible, downstream of first hidden) | **Was broken** — now loads correctly with no flicker. |
| ON | `/gage/SVPA-25` (hidden, downstream of first hidden) | Loads correctly with no flicker. |
| OFF | `/gage/USGS-9999` (unknown) | Renders loading/empty state. Toggle stays OFF. |
