### PR TITLE
feat: page titles

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -16,7 +16,7 @@ export default {
   web: {
     bundler: "metro",
     favicon: "./assets/favicon-180.png",
-    title: "Floodzilla Gauge Network - SVPA",
+    title: "Floodzilla Gauge Network",
     description:
       "A network of river gauges on the Snoqualmie River deployed and managed by The Snoqualmie Valley Preservation Alliance",
     splash: {

--- a/app/(root)/forecast/[...id].tsx
+++ b/app/(root)/forecast/[...id].tsx
@@ -55,7 +55,13 @@ const ForecastDetailsBody = observer(function ForecastDetailsBody({ gageId }: { 
 
   return (
     <Screen>
-      <PageTitle name={forecastGage?.title ? `${forecastGage.title} Forecast` : undefined} />
+      <PageTitle
+        name={
+          forecastGage?.title
+            ? `${forecastGage.title} ${t("navigation.forecastScreen")}`
+            : undefined
+        }
+      />
       <Stack.Screen
         options={{
           title: `${t("common.title")} - ${t("forecastScreen.title")}: ${forecastGage?.title}`,

--- a/app/(root)/forecast/[...id].tsx
+++ b/app/(root)/forecast/[...id].tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { ErrorBoundaryProps, Stack, useGlobalSearchParams } from "expo-router";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 import { observer } from "mobx-react-lite";
 
@@ -55,11 +55,7 @@ const ForecastDetailsBody = observer(function ForecastDetailsBody({ gageId }: { 
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("forecastScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={forecastGage?.title ? `${forecastGage.title} Forecast` : undefined} />
       <Stack.Screen
         options={{
           title: `${t("common.title")} - ${t("forecastScreen.title")}: ${forecastGage?.title}`,

--- a/app/(root)/forecast/index.tsx
+++ b/app/(root)/forecast/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { ErrorBoundaryProps, Stack, useRouter } from "expo-router";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 import { observer } from "mobx-react-lite";
 
@@ -63,12 +63,7 @@ const ForecastScreen = observer(function ForecastScreen() {
 
   return (
     <Screen>
-      {/* This is purely for documentTitle setting */}
-      <Head>
-        <title>
-          {t("common.title")} - {t("forecastScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("navigation.forecastScreen")} />
       <Content scrollable onRefresh={fetchData}>
         <ForecastChart gages={forecastGages} />
         <RowOrCell flex align="flex-start" justify="stretch" top={Spacing.mediumXL}>

--- a/app/(root)/gage/[id].tsx
+++ b/app/(root)/gage/[id].tsx
@@ -184,7 +184,13 @@ const GageDetailsBody = observer(function GageDetailsBody({ gageId }: { gageId: 
 
   return (
     <Screen>
-      <PageTitle name={`${gage.locationInfo?.locationName} (${gageId})`} />
+      <PageTitle
+        name={
+          gage.locationInfo?.locationName
+            ? `${gage.locationInfo.locationName} (${gageId})`
+            : undefined
+        }
+      />
       <Stack.Screen
         options={{
           title: `${gage?.locationInfo?.locationName} | ${t("common.title")} - ${t(

--- a/app/(root)/gage/[id].tsx
+++ b/app/(root)/gage/[id].tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from "react";
 import { TouchableOpacity } from "react-native";
 import { ErrorBoundaryProps, Link, Stack, useLocalSearchParams } from "expo-router";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 import { observer } from "mobx-react-lite";
 
@@ -184,11 +184,7 @@ const GageDetailsBody = observer(function GageDetailsBody({ gageId }: { gageId: 
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={`${gage.locationInfo?.locationName} (${gageId})`} />
       <Stack.Screen
         options={{
           title: `${gage?.locationInfo?.locationName} | ${t("common.title")} - ${t(
@@ -298,7 +294,6 @@ const GageDetailsBody = observer(function GageDetailsBody({ gageId }: { gageId: 
 
 const GageScreen = observer(function GageScreen() {
   const { id } = useLocalSearchParams();
-  const { t } = useLocale();
   const store = useStores();
   const { isHiddenLocation, setShowHiddenOffline, showHiddenOffline } = store;
 
@@ -343,11 +338,7 @@ const GageScreen = observer(function GageScreen() {
   if (initialIndex === -1) {
     return (
       <>
-        <Head>
-          <title>
-            {t("common.title")} - {t("homeScreen.title")}
-          </title>
-        </Head>
+        <PageTitle />
         <EmptyComponent />
       </>
     );

--- a/app/(root)/gage/index.tsx
+++ b/app/(root)/gage/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { ViewStyle, FlatList, TouchableOpacity, useWindowDimensions } from "react-native";
 import { ErrorBoundaryProps, Link, useRouter } from "expo-router";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 import { observer } from "mobx-react-lite";
 
@@ -218,11 +218,7 @@ const HomeScreen = observer(function HomeScreen() {
 
   const baseControls = (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("pageTitles.gageList")} />
       <Row justify="flex-start">
         <If condition={!isMobile}>
           <Card

--- a/app/(root)/index.tsx
+++ b/app/(root)/index.tsx
@@ -2,18 +2,14 @@ import React from "react";
 import { Redirect } from "expo-router";
 import { ROUTES } from "app/_layout";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 export default function Index() {
   const { t } = useLocale();
 
   return (
     <>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("pageTitles.gageList")} />
       <Redirect href={ROUTES.Gages} />
     </>
   );

--- a/app/(root)/user/alerts.tsx
+++ b/app/(root)/user/alerts.tsx
@@ -29,7 +29,7 @@ import ErrorMessage from "@common-ui/components/ErrorMessage";
 import { Gage } from "@models/Gage";
 import { Switch } from "react-native";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 import { FLink } from "@common-ui/components/FLink";
 
 // We use this to wrap each screen with an error boundary
@@ -346,11 +346,7 @@ const AlertsScreen = observer(function AlertsScreen() {
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("pageTitles.alerts")} />
       <TitleWithBackButton
         title={t("navigation.alertsScreen")}
         onPress={goBack}

--- a/app/(root)/user/changeemail.tsx
+++ b/app/(root)/user/changeemail.tsx
@@ -18,7 +18,7 @@ import { If } from "@common-ui/components/Conditional";
 import ErrorMessage from "@common-ui/components/ErrorMessage";
 import { useValidations } from "@utils/useValidations";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 // We use this to wrap each screen with an error boundary
 export function ErrorBoundary(props: ErrorBoundaryProps) {
@@ -49,11 +49,7 @@ const ChangeEmailScreen = observer(function ChangeEmailScreen() {
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("navigation.changeemailScreen")} />
       <TitleWithBackButton title={t("navigation.changeemailScreen")} onPress={goBack} />
       <Content maxWidth={Spacing.tabletWidth} scrollable>
         <Card bottom={Spacing.large}>

--- a/app/(root)/user/createpassword.tsx
+++ b/app/(root)/user/createpassword.tsx
@@ -11,7 +11,7 @@ import { ROUTES } from "app/_layout";
 import ChangePasswordForm, { PasswordSubmitActionProps } from "@components/ChangePasswordForm";
 import { Spacing } from "@common-ui/constants/spacing";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 // We use this to wrap each screen with an error boundary
 export function ErrorBoundary(props: ErrorBoundaryProps) {
@@ -40,11 +40,7 @@ const CreatePasswordScreen = observer(function CreatePasswordScreen() {
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("navigation.passwordCreateScreen")} />
       <TitleWithBackButton title={t("navigation.passwordCreateScreen")} onPress={goBack} />
       <Content maxWidth={Spacing.tabletWidth} scrollable>
         <ChangePasswordForm

--- a/app/(root)/user/index.tsx
+++ b/app/(root)/user/index.tsx
@@ -20,7 +20,7 @@ import { useStores } from "@models/helpers/useStores";
 import { observer } from "mobx-react-lite";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
 import LocaleChange from "@components/LocaleChange";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 // We use this to wrap each screen with an error boundary
 export function ErrorBoundary(props: ErrorBoundaryProps) {
@@ -82,11 +82,7 @@ const AboutScreen = observer(function AboutScreen() {
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("navigation.aboutScreen")} />
       <Stack.Screen options={{ title: `${t("common.title")} - ${t("homeScreen.title")}` }} />
       {/* Header */}
       <Cell horizontal={Spacing.medium} bottom={Spacing.extraSmall} top={Spacing.medium}>

--- a/app/(root)/user/login.tsx
+++ b/app/(root)/user/login.tsx
@@ -21,7 +21,7 @@ import { useValidations } from "@utils/useValidations";
 import GoogleSigninButton from "@components/GoogleSigninButton";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
 import { AppleSigninButton } from "@components/AppleSigninButton";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 // We use this to wrap each screen with an error boundary
 export function ErrorBoundary(props: ErrorBoundaryProps) {
@@ -83,11 +83,7 @@ const LoginScreen = observer(function LoginScreen() {
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("navigation.loginScreen")} />
       <TitleWithBackButton title={t("navigation.loginScreen")} onPress={goBack} />
       <Content maxWidth={Spacing.tabletWidth} scrollable>
         <Card bottom={Spacing.large}>

--- a/app/(root)/user/new.tsx
+++ b/app/(root)/user/new.tsx
@@ -21,7 +21,7 @@ import Config from "@config/config";
 import GoogleSigninButton from "@components/GoogleSigninButton";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
 import { AppleSigninButton } from "@components/AppleSigninButton";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 // We use this to wrap each screen with an error boundary
 export function ErrorBoundary(props: ErrorBoundaryProps) {
@@ -112,11 +112,7 @@ const NewScreen = observer(function NewScreen() {
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("navigation.newAccountScreen")} />
       <TitleWithBackButton title={t("navigation.newAccountScreen")} onPress={goBack} />
       <Content maxWidth={Spacing.tabletWidth} scrollable>
         <Card bottom={Spacing.large}>

--- a/app/(root)/user/passwordForgot.tsx
+++ b/app/(root)/user/passwordForgot.tsx
@@ -18,7 +18,7 @@ import { If } from "@common-ui/components/Conditional";
 import ErrorMessage from "@common-ui/components/ErrorMessage";
 import { useValidations } from "@utils/useValidations";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 // We use this to wrap each screen with an error boundary
 export function ErrorBoundary(props: ErrorBoundaryProps) {
@@ -70,11 +70,7 @@ const PasswordForgotScreen = observer(function PasswordForgotScreen() {
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("navigation.passwordForgotScreen")} />
       <TitleWithBackButton title={t("navigation.passwordForgotScreen")} onPress={goBack} />
       <Content maxWidth={Spacing.tabletWidth} scrollable>
         <Card bottom={Spacing.large}>

--- a/app/(root)/user/privacy.tsx
+++ b/app/(root)/user/privacy.tsx
@@ -13,7 +13,7 @@ import { isMobile } from "@common-ui/utils/responsive";
 import { If } from "@common-ui/components/Conditional";
 import { ROUTES } from "app/_layout";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 // We use this to wrap each screen with an error boundary
 export function ErrorBoundary(props: ErrorBoundaryProps) {
@@ -40,11 +40,7 @@ const PrivacyPolicyScreen = () => {
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("navigation.privacyPolicyScreen")} />
       <Content scrollable>
         {/* SECTION */}
         <Row>

--- a/app/(root)/user/profile.tsx
+++ b/app/(root)/user/profile.tsx
@@ -23,7 +23,7 @@ import SuccessMessage from "@common-ui/components/SuccessMessage";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
 import { Alert } from "react-native";
 import { isMobile } from "@common-ui/utils/responsive";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 // We use this to wrap each screen with an error boundary
 export function ErrorBoundary(props: ErrorBoundaryProps) {
@@ -118,11 +118,7 @@ const ProfileScreen = observer(function ProfileScreen() {
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("profileScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("navigation.profileScreen")} />
       <TitleWithBackButton title={t("navigation.profileScreen")} onPress={goBack} />
       <Content maxWidth={Spacing.tabletWidth} scrollable>
         <Card bottom={Spacing.large}>

--- a/app/(root)/user/resetpassword.tsx
+++ b/app/(root)/user/resetpassword.tsx
@@ -12,7 +12,7 @@ import ChangePasswordForm, { PasswordSubmitActionProps } from "@components/Chang
 import { Spacing } from "@common-ui/constants/spacing";
 import { normalizeSearchParams } from "@utils/navigation";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 // We use this to wrap each screen with an error boundary
 export function ErrorBoundary(props: ErrorBoundaryProps) {
@@ -56,11 +56,7 @@ const ResetPasswordScreen = observer(function ResetPasswordScreen() {
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("navigation.passwordResetScreen")} />
       <TitleWithBackButton title={t("navigation.passwordResetScreen")} onPress={goBack} />
       <Content maxWidth={Spacing.tabletWidth} scrollable>
         <ChangePasswordForm

--- a/app/(root)/user/setpassword.tsx
+++ b/app/(root)/user/setpassword.tsx
@@ -11,7 +11,7 @@ import { ROUTES } from "app/_layout";
 import ChangePasswordForm, { PasswordSubmitActionProps } from "@components/ChangePasswordForm";
 import { Spacing } from "@common-ui/constants/spacing";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 // We use this to wrap each screen with an error boundary
 export function ErrorBoundary(props: ErrorBoundaryProps) {
@@ -41,11 +41,7 @@ const SetPasswordScreen = observer(function SetPasswordScreen() {
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("navigation.passwordSetScreen")} />
       <TitleWithBackButton title={t("navigation.passwordSetScreen")} onPress={goBack} />
       <Content maxWidth={Spacing.tabletWidth} scrollable>
         <ChangePasswordForm

--- a/app/(root)/user/terms.tsx
+++ b/app/(root)/user/terms.tsx
@@ -22,7 +22,7 @@ import Config from "@config/config";
 import { isMobile } from "@common-ui/utils/responsive";
 import { If } from "@common-ui/components/Conditional";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 // We use this to wrap each screen with an error boundary
 export function ErrorBoundary(props: ErrorBoundaryProps) {
@@ -56,11 +56,7 @@ const TermsOfUseScreen = () => {
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("navigation.termsOfServiceScreen")} />
       <Content scrollable>
         <Row>
           <If condition={isMobile}>

--- a/app/(root)/user/unsubscribe.tsx
+++ b/app/(root)/user/unsubscribe.tsx
@@ -18,7 +18,7 @@ import ErrorMessage from "@common-ui/components/ErrorMessage";
 import { normalizeSearchParams, openLinkInBrowser } from "@utils/navigation";
 import SuccessMessage from "@common-ui/components/SuccessMessage";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 // We use this to wrap each screen with an error boundary
 export function ErrorBoundary(props: ErrorBoundaryProps) {
@@ -63,11 +63,7 @@ const UnsubscribeScreen = observer(function UnsubscribeScreen() {
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("navigation.unsubscribeScreen")} />
       <TitleWithBackButton title={t("navigation.unsubscribeScreen")} onPress={goBack} />
       <Content maxWidth={Spacing.tabletWidth} scrollable>
         <Card bottom={Spacing.large}>

--- a/app/(root)/user/verifyPhoneNumber.tsx
+++ b/app/(root)/user/verifyPhoneNumber.tsx
@@ -19,7 +19,7 @@ import { If } from "@common-ui/components/Conditional";
 import ErrorMessage from "@common-ui/components/ErrorMessage";
 import { useValidations } from "@utils/useValidations";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 // We use this to wrap each screen with an error boundary
 export function ErrorBoundary(props: ErrorBoundaryProps) {
@@ -82,11 +82,7 @@ const VerifyPhoneNumberScreen = observer(function VerifyPhoneNumberScreen() {
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("navigation.verifyPhoneNnumberScreen")} />
       <TitleWithBackButton title={title} onPress={goBack} />
       <Content maxWidth={Spacing.tabletWidth} scrollable>
         <Card bottom={Spacing.large}>

--- a/app/(root)/user/verifyPhoneNumber.tsx
+++ b/app/(root)/user/verifyPhoneNumber.tsx
@@ -73,28 +73,28 @@ const VerifyPhoneNumberScreen = observer(function VerifyPhoneNumberScreen() {
   };
 
   const title = authSessionStore.userPhone
-    ? t("navigation.changePhoneNnumberScreen")
-    : t("navigation.verifyPhoneNnumberScreen");
+    ? t("navigation.changePhoneNumberScreen")
+    : t("navigation.verifyPhoneNumberScreen");
 
   const sendButtonTitle = codeSent
-    ? t("verifyphonenumberScreen.resendVerification")
-    : t("verifyphonenumberScreen.sendVerification");
+    ? t("verifyPhoneNumberScreen.resendVerification")
+    : t("verifyPhoneNumberScreen.sendVerification");
 
   return (
     <Screen>
-      <PageTitle name={t("navigation.verifyPhoneNnumberScreen")} />
+      <PageTitle name={title} />
       <TitleWithBackButton title={title} onPress={goBack} />
       <Content maxWidth={Spacing.tabletWidth} scrollable>
         <Card bottom={Spacing.large}>
           <CardContent>
             {/* Description */}
             <RegularText lineHeight={Spacing.large}>
-              {t("verifyphonenumberScreen.description")}
+              {t("verifyPhoneNumberScreen.description")}
             </RegularText>
             {/* Phone Number */}
             <RowOrCell vertical={Spacing.small}>
               <Cell flex={1}>
-                <MediumText>{t("verifyphonenumberScreen.phoneNumber")}</MediumText>
+                <MediumText>{t("verifyPhoneNumberScreen.phoneNumber")}</MediumText>
               </Cell>
               <Cell flex={5}>
                 <Input
@@ -123,16 +123,16 @@ const VerifyPhoneNumberScreen = observer(function VerifyPhoneNumberScreen() {
               <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"}>
                 <Spacer />
                 <RegularText>
-                  {t("verifyphonenumberScreen.confirmationText", { phoneNumber: phone })}
+                  {t("verifyPhoneNumberScreen.confirmationText", { phoneNumber: phone })}
                 </RegularText>
                 <RowOrCell vertical={Spacing.small}>
                   <Cell flex={1}>
-                    <MediumText>{t("verifyphonenumberScreen.verificationCode")}</MediumText>
+                    <MediumText>{t("verifyPhoneNumberScreen.verificationCode")}</MediumText>
                   </Cell>
                   <Cell flex={5}>
                     <Input
                       value=""
-                      placeholder={t("verifyphonenumberScreen.verificationCodePlaceholder")}
+                      placeholder={t("verifyPhoneNumberScreen.verificationCodePlaceholder")}
                       onChangeText={setCode}
                       keyboardType="number-pad"
                     />
@@ -144,7 +144,7 @@ const VerifyPhoneNumberScreen = observer(function VerifyPhoneNumberScreen() {
                     isLoading={authSessionStore.isFetching}
                     minWidth={Spacing.extraExtraHuge}
                     selfAlign="center"
-                    title={t("verifyphonenumberScreen.submit")}
+                    title={t("verifyPhoneNumberScreen.submit")}
                     onPress={submitCodeVerification}
                     type="blue"
                   />

--- a/app/(root)/user/verifyemail.tsx
+++ b/app/(root)/user/verifyemail.tsx
@@ -17,7 +17,7 @@ import ErrorMessage from "@common-ui/components/ErrorMessage";
 import { normalizeSearchParams } from "@utils/navigation";
 import SuccessMessage from "@common-ui/components/SuccessMessage";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
-import Head from "expo-router/head";
+import PageTitle from "@common-ui/components/PageTitle";
 
 // We use this to wrap each screen with an error boundary
 export function ErrorBoundary(props: ErrorBoundaryProps) {
@@ -54,11 +54,7 @@ const VerifyEmailScreen = observer(function VerifyEmailScreen() {
 
   return (
     <Screen>
-      <Head>
-        <title>
-          {t("common.title")} - {t("homeScreen.title")}
-        </title>
-      </Head>
+      <PageTitle name={t("navigation.verifyemailScreen")} />
       <TitleWithBackButton title={t("navigation.verifyemailScreen")} onPress={goBack} />
       <Content maxWidth={Spacing.tabletWidth} scrollable>
         <Card bottom={Spacing.large}>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -129,9 +129,7 @@ function App() {
             rel="stylesheet"
             href="https://fonts.googleapis.com/css?family=Montserrat:300,400,500,600,700|Open+Sans:300,400,500,600,700;lang=en"
           />
-          <title>
-            {t("common.title")} - {t("homeScreen.title")}
-          </title>
+          <title>{t("common.title")}</title>
           <meta name="description" content={t("common.metaDescription")} />
           <meta property="expo:handoff" content="true" />
           <meta name="apple-itunes-app" content="app-id=6448645748" />

--- a/src/common-ui/components/PageTitle.tsx
+++ b/src/common-ui/components/PageTitle.tsx
@@ -22,7 +22,7 @@ export default function PageTitle({ name }: PageTitleProps) {
   }
 
   const brand = t("common.title");
-  const title = name ? `${name} — ${brand}` : brand;
+  const title = name ? `${name} - ${brand}` : brand;
 
   return (
     <Head>

--- a/src/common-ui/components/PageTitle.tsx
+++ b/src/common-ui/components/PageTitle.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import Head from "expo-router/head";
+
+import { useLocale } from "@common-ui/contexts/LocaleContext";
+import { isWeb } from "@common-ui/utils/responsive";
+
+type PageTitleProps = {
+  /** Page-specific name. When omitted, only the brand is shown. */
+  name?: string;
+};
+
+/**
+ * Sets the web document <title> in the format `{name} — {brand}`, where brand is
+ * the localized app title (common.title). No-op on native — native navigation
+ * titles are set per-screen via <Stack.Screen options={{ title }}>.
+ */
+export default function PageTitle({ name }: PageTitleProps) {
+  const { t } = useLocale();
+
+  if (!isWeb) {
+    return null;
+  }
+
+  const brand = t("common.title");
+  const title = name ? `${name} — ${brand}` : brand;
+
+  return (
+    <Head>
+      <title>{title}</title>
+    </Head>
+  );
+}

--- a/src/common-ui/components/__tests__/PageTitle.test.tsx
+++ b/src/common-ui/components/__tests__/PageTitle.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+import PageTitle from "../PageTitle";
+
+// Head renders its children through unchanged so we can inspect the <title>.
+jest.mock("expo-router/head", () => ({
+  __esModule: true,
+  default: ({ children }: any) => children,
+}));
+
+jest.mock("@common-ui/contexts/LocaleContext", () => ({
+  useLocale: () => ({
+    t: (key: string) => (key === "common.title" ? "Floodzilla Gauge Network" : key),
+  }),
+}));
+
+jest.mock("@common-ui/utils/responsive", () => ({ isWeb: true }));
+
+describe("PageTitle", () => {
+  it("renders '<name> — <brand>' when a name is provided", () => {
+    const tree = JSON.stringify(render(<PageTitle name="Forecast" />).toJSON());
+    expect(tree).toContain("Forecast — Floodzilla Gauge Network");
+  });
+
+  it("renders brand only when name is omitted", () => {
+    const tree = JSON.stringify(render(<PageTitle />).toJSON());
+    expect(tree).toContain("Floodzilla Gauge Network");
+    expect(tree).not.toContain(" — ");
+  });
+});

--- a/src/common-ui/components/__tests__/PageTitle.test.tsx
+++ b/src/common-ui/components/__tests__/PageTitle.test.tsx
@@ -20,7 +20,7 @@ jest.mock("@common-ui/utils/responsive", () => ({ isWeb: true }));
 describe("PageTitle", () => {
   it("renders '<name> — <brand>' when a name is provided", () => {
     const tree = JSON.stringify(render(<PageTitle name="Forecast" />).toJSON());
-    expect(tree).toContain("Forecast — Floodzilla Gauge Network");
+    expect(tree).toContain("Forecast - Floodzilla Gauge Network");
   });
 
   it("renders brand only when name is omitted", () => {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -66,6 +66,10 @@ const en = {
     logout: "Logout",
     back: "Go Back",
   },
+  pageTitles: {
+    gageList: "Snoqualmie River Gauges",
+    alerts: "Flood Alerts",
+  },
   homeScreen: {
     title: "Snoqualmie River / SVPA",
   },

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -56,8 +56,8 @@ const en = {
     passwordResetScreen: "Reset Password",
     passwordSetScreen: "Change Password",
     passwordCreateScreen: "Choose Password",
-    verifyPhoneNnumberScreen: "Verify Phone Number",
-    changePhoneNnumberScreen: "Change Phone Number",
+    verifyPhoneNumberScreen: "Verify Phone Number",
+    changePhoneNumberScreen: "Change Phone Number",
     changeemailScreen: "Change Email Address",
     verifyemailScreen: "Verify Email Address",
     unsubscribeScreen: "Unsubscribe",
@@ -208,7 +208,7 @@ const en = {
     successMessage: "Your email address has been verified.",
     continue: "Continue to Floodzilla",
   },
-  verifyphonenumberScreen: {
+  verifyPhoneNumberScreen: {
     sendVerification: "Send Verification Code",
     resendVerification: "Resend Verification Code",
     description:

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -68,6 +68,10 @@ const es = {
     logout: "Cerrar sesión",
     back: "Volver",
   },
+  pageTitles: {
+    gageList: "Medidores del río Snoqualmie",
+    alerts: "Alertas de inundación",
+  },
   homeScreen: {
     title: "Río Snoqualmie / SVPA",
   },

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -58,8 +58,8 @@ const es = {
     passwordResetScreen: "Restablecer contraseña",
     passwordSetScreen: "Cambiar contraseña",
     passwordCreateScreen: "Elegir contraseña",
-    verifyPhoneNnumberScreen: "Verificar número de teléfono",
-    changePhoneNnumberScreen: "Cambiar número de teléfono",
+    verifyPhoneNumberScreen: "Verificar número de teléfono",
+    changePhoneNumberScreen: "Cambiar número de teléfono",
     changeemailScreen: "Cambiar correo electrónico",
     verifyemailScreen: "Verificar dirección de correo electrónico",
     unsubscribeScreen: "Darse de baja",
@@ -211,7 +211,7 @@ const es = {
     successMessage: "Tu dirección de correo electrónico ha sido verificada.",
     continue: "Continuar a Floodzilla",
   },
-  verifyphonenumberScreen: {
+  verifyPhoneNumberScreen: {
     sendVerification: "Enviar código de verificación",
     resendVerification: "Reenviar código de verificación",
     description:


### PR DESCRIPTION
# Distinct web page titles

## Summary

While I was fixing the deep linking issue I noticed that every web screen rendered the **same** generic browser-tab title
(`Floodzilla Gauge Network - Snoqualmie River / SVPA`), copy-pasted as an inline
`<Head><title>` block in ~20 files. This PR replaces all of them with a single
`PageTitle` component so each route gets a distinct, descriptive tab title in one
consistent format:

```
{name} - Floodzilla Gauge Network
```

Examples: `Forecast - Floodzilla Gauge Network`,
`Tolt River near Carnation (38) - Floodzilla Gauge Network`,
`Flood Alerts - Floodzilla Gauge Network`.

Scope is **titles only** for the current SPA web build - no Open Graph/Twitter
cards, canonical URLs, or static (SSG) pre-rendering (see "Out of scope").

## What changed

- **New `src/common-ui/components/PageTitle.tsx`** - wraps `expo-router/head` and
  emits `{name} - {brand}` (brand = `t("common.title")`, localized), or brand-only
  when `name` is omitted. No-op on native (native nav titles still come from
  `<Stack.Screen>`). Unit-tested.
- **Migrated all web screens** to `<PageTitle name={…} />`: gage list + detail,
  forecast list + detail, the root `(root)/index` redirect, and all 15
  `user/*` screens. The only remaining `<Head>` is the root `app/_layout.tsx`
  (favicon, meta, scripts, brand-only fallback title).
- **Dynamic titles** on detail pages, with graceful fallbacks while data loads:
  - Gage detail → `"<location name> (<id>)"`, brand-only until `locationInfo`
    resolves.
  - Forecast detail → `"<gage title> <forecast>"` (the "forecast" word is
    localized via `navigation.forecastScreen`), brand-only until the gage loads.
- **i18n** - added a `pageTitles` section (`gageList`, `alerts`) to both `en.ts`
  and `es.ts`. These are dedicated title-only keys so the longer tab titles don't
  change the shorter visible nav labels ("Gauges", "Alerts"). All other titles
  reuse existing `navigation.*` keys, so Spanish gets the em-dash format
  automatically.
- **Cleanups** - root fallback `<title>` and `app.config.ts` `web.title`
  simplified to the brand.

## Out of scope (intentionally deferred)

Because the web build is an SPA, these titles are set client-side after JS runs -
correct for browser tabs and bookmarks, but social-media crawlers / non-JS SEO
bots still see only the build-time title. Open Graph/Twitter cards, canonical
URLs, sitemap/robots, structured data, and static (SSG) pre-rendering would
require switching `output` to `"static"` and are deliberately not included here.

Note: `app.config.ts`'s `web.title` does not drive the generated
`dist/index.html` `<title>` (that comes from the app `name`, "Floodzilla"), so the
pre-mount static tab briefly reads "Floodzilla" before React mounts and sets the
real title. Harmless; flagged for awareness.

## Test plan

- [x] `npm test` - 366 pass (incl. new `PageTitle` unit tests). One pre-existing,
      unrelated suite failure (`GageDetailsChart.slot-interval`, a chart-module
      resolution issue) is untouched by this PR.
- [x] `npm run lint` - 0 errors.
- [x] `npx tsc --noEmit` - clean.
- [x] `npx expo export --platform web` - builds successfully.
- [ ] Manual: `npx serve dist --single`, click through routes and confirm each
      browser tab shows its mapped title (including dynamic gage/forecast pages),
      then switch locale to Spanish and re-check `/gage` and `/user/alerts`.

## Notes for reviewers

This branch is based on `fix/deep-link-hidden-gauge`, so it currently also
contains those two commits. If that branch isn't merged to `main` first, rebase
this onto `main` (or merge the base branch first) so the PR diff is titles-only.
