### PR TITLE
fix broken tests

### DIFF
--- a/src/models/helpers/__tests__/setupRootStore.test.ts
+++ b/src/models/helpers/__tests__/setupRootStore.test.ts
@@ -5,6 +5,14 @@ import { setupRootStore } from "../setupRootStore";
 jest.mock("@utils/storage", () => ({
   load: jest.fn(),
   save: jest.fn().mockResolvedValue(true),
+  remove: jest.fn().mockResolvedValue(true),
+}));
+
+// Debug-flag plumbing is unrelated to stub rehydration. setupRootStore awaits
+// loadDebugFlags() first, which would otherwise consume the single mocked
+// storage.load snapshot meant for the root store. Stub it out.
+jest.mock("@utils/debugFlags", () => ({
+  loadDebugFlags: jest.fn().mockResolvedValue(undefined),
 }));
 
 // setupRootStore calls api.setHeader when an auth token is present. Stub it.


### PR DESCRIPTION
## Fix broken `setupRootStore` stub-rehydration tests

### Summary

Two tests in `setupRootStore.test.ts` were failing on `main` with
`TypeError: storage.remove is not a function`. This isolates the tests from the
debug-flag plumbing that started running inside `setupRootStore`, restoring a
green suite (370/370).

### Root cause — a semantic merge conflict, not a regression

The test and the code that breaks it landed on two separate branches, each green
in isolation:

| Branch / PR | Has the test? | Has `loadDebugFlags()` in `setupRootStore`? | Result |
|---|---|---|---|
| **PR #49** `feat/native-navigation-improvements` (test added) | ✅ | ❌ not yet | green — `storage.load` called once, snapshot reaches the root store |
| **PR #53** `feat/show-deleted-readings` (debug plumbing added) | ❌ never had it | ✅ | green — no test to exercise the new path |

`feat/show-deleted-readings` last synced with `main` *before* PR #49's test
landed, so its CI never saw the test. The two only met when PR #53 merged into
`main` — git merged cleanly (different files, no textual conflict), but the
combined behavior broke.

Once combined, `setupRootStore` does `await loadDebugFlags()` **before** loading
the root snapshot. In the test that has two unanticipated effects:

1. `loadDebugFlags` calls `storage.load(...)` first, **consuming the test's
   single `mockResolvedValueOnce`** snapshot meant for the root store.
2. With no `expiresAt` on that object, it calls `storage.remove(...)` — which the
   test's storage mock never defined → `TypeError`.

No production code is wrong; the test was simply unaware of plumbing added on a
parallel branch.

### Fix

Isolate the unit under test:

- Mock `@utils/debugFlags.loadDebugFlags` to a no-op so it no longer steals the
  one-shot `storage.load` snapshot.
- Add `remove` to the `@utils/storage` mock as a safety net.

### Testing

- `npm test` → **370 passed, 48 suites, 0 failed** (was 368 passed / 2 failed).
