### PR TITLE
fix: chart corruption on auto refresh

### DIFF
--- a/src/models/Gage.ts
+++ b/src/models/Gage.ts
@@ -453,9 +453,28 @@ export const GageStoreModel = types
           gage?.setProp("lastReadingId", undefined);
         }
 
-        // If last reading id is included - add it to the readings array
+        // If last reading id is included - merge the incremental readings in.
+        // `readings` is kept newest-first (descending): the chart reverses it
+        // before plotting and predictedPoints uses readings[0] as the latest
+        // reading. The new readings are the newest, so they must go at the front
+        // and the merged array must stay sorted descending — appending them to
+        // the end instead draws a spurious chart line from the newest point back
+        // to the oldest. Dedupe by id in case the API resends the boundary reading.
         if (includeLastReading) {
-          gage?.setProp("readings", [...gage.readings, ...data.readings]);
+          const seen = new Set<number>();
+          const merged = [...data.readings, ...gage.readings].filter((r) => {
+            if (r.id == null) {
+              return true;
+            }
+            if (seen.has(r.id)) {
+              return false;
+            }
+            seen.add(r.id);
+            return true;
+          });
+          // Descending (newest first); ISO timestamps sort lexically.
+          merged.sort((a, b) => (b.timestamp ?? "").localeCompare(a.timestamp ?? ""));
+          gage?.setProp("readings", merged);
         } else {
           // Otherwise, just replace the readings array
           gage?.setProp("readings", data.readings);

--- a/src/models/__tests__/fetchDataForGage.ordering.test.ts
+++ b/src/models/__tests__/fetchDataForGage.ordering.test.ts
@@ -1,0 +1,73 @@
+import { GageStoreModel } from "../Gage";
+import { api } from "@services/api";
+
+// The store keeps `readings` newest-first (descending). The chart relies on this:
+// useGageChartOptions reverses the array before plotting, and Gage.predictedPoints
+// uses readings[0] as the latest reading. The live-polling append must preserve it.
+jest.mock("@services/api", () => ({
+  api: { getGageReadings: jest.fn() },
+}));
+
+const buildStore = () =>
+  GageStoreModel.create({
+    gages: [
+      {
+        locationId: "USGS-38",
+        lastReadingId: 100,
+        readings: [
+          { id: 100, timestamp: "2026-06-10T12:00:00", waterHeight: 5 },
+          { id: 99, timestamp: "2026-06-10T11:00:00", waterHeight: 4 },
+          { id: 98, timestamp: "2026-06-10T10:00:00", waterHeight: 3 },
+        ],
+      } as any,
+    ],
+  });
+
+describe("GageStore.fetchDataForGage — live append ordering", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("keeps readings newest-first after an incremental live append", async () => {
+    const store = buildStore();
+
+    (api.getGageReadings as jest.Mock).mockResolvedValue({
+      kind: "ok",
+      data: {
+        lastReadingId: 102,
+        readings: [
+          { id: 102, timestamp: "2026-06-10T14:00:00", waterHeight: 7 },
+          { id: 101, timestamp: "2026-06-10T13:00:00", waterHeight: 6 },
+        ],
+        predictions: [],
+      },
+    });
+
+    // includeLastReading=true → the incremental append branch the live poll uses.
+    await store.fetchDataForGage("USGS-38", undefined, undefined, true, true);
+
+    const ids = store.gages[0].readings.map((r) => r.id);
+    // The just-fetched newest reading (102) must be at the front, not appended to
+    // the end where it would create a spurious chart segment back to the oldest point.
+    expect(ids).toEqual([102, 101, 100, 99, 98]);
+  });
+
+  it("does not duplicate a reading if the API resends one at the boundary", async () => {
+    const store = buildStore();
+
+    (api.getGageReadings as jest.Mock).mockResolvedValue({
+      kind: "ok",
+      data: {
+        lastReadingId: 101,
+        readings: [
+          { id: 101, timestamp: "2026-06-10T13:00:00", waterHeight: 6 },
+          { id: 100, timestamp: "2026-06-10T12:00:00", waterHeight: 5 },
+        ],
+        predictions: [],
+      },
+    });
+
+    await store.fetchDataForGage("USGS-38", undefined, undefined, true, true);
+
+    const ids = store.gages[0].readings.map((r) => r.id);
+    expect(ids).toEqual([101, 100, 99, 98]);
+  });
+});


### PR DESCRIPTION
## Fix gauge chart line breaking on live auto-refresh

### Problem

On the gauge details page, the chart line gets corrupted whenever live polling auto-refreshes and pulls in a new reading. Instead of extending the line at the right edge, the chart draws a spurious segment from the newest point straight back to the first point ~2 days ago.

### Root cause

`gage.readings` is maintained **newest-first (descending)** throughout the codebase:

- The chart reverses the array before plotting (`useGageChartOptions.ts`), since Highcharts needs points ascending by time.
- `Gage.predictedPoints` uses `readings[0]` as the *latest* reading to connect the prediction line.

The incremental live fetch (`fetchDataForGage` with `includeLastReading=true`) returns the **newest** readings but appended them to the **end** of the array:

```js
gage.setProp("readings", [...gage.readings, ...data.readings]);
```

That broke the descending invariant. After the chart's `.reverse()`, the just-added newest points landed at the front, directly adjacent to the oldest reading — so the line jumped from the newest point back to the start of the window.

This only surfaced *after* the first refresh because the initial load takes the *replace* branch (`includeLastReading=false`), which stores the API's already-descending array correctly.

### Fix

Merge incremental readings into the existing array and re-sort newest-first by timestamp, so the invariant holds regardless of the API's return order. Added a dedupe-by-id guard in case the API re-sends the boundary reading (which would otherwise plant a duplicate chart point).

### Tests

Added `src/models/__tests__/fetchDataForGage.ordering.test.ts`:

- asserts readings stay newest-first after an incremental append (the reported bug)
- asserts no duplication when a boundary reading is resent

Both fail on the old code and pass with the fix. Full suite (49 suites / 372 tests), `tsc --noEmit`, and `npm run lint` are green.

### Out of scope (noted for follow-up)

The live poll advances the window start with wall time but never trims readings that scroll off the left edge, so the array grows over a long session. Not visually broken and unrelated to this bug — flagging for a possible later cleanup.
