### PR TITLE
Fix web map crash on fresh load when region is not yet available

### DIFF
--- a/src/components/MapLibreWebGageMap.tsx
+++ b/src/components/MapLibreWebGageMap.tsx
@@ -117,6 +117,15 @@ const MapLibreWebGageWebMap = ({
     return defaultMapBounds as [number, number, number, number];
   }, [region, singleGage]);
 
+  // Until the region (and thus a real map style) is available, don't mount the
+  // map. react-maplibre normalizes an empty mapStyle to null, which leaves the
+  // underlying maplibre map without a `style` object and then crashes in its
+  // _updateStyleComponents (`map.style._loaded`). This happens on a fresh load
+  // (e.g. incognito) before region data is fetched.
+  if (!mapStyle) {
+    return null;
+  }
+
   return (
     <Map
       initialViewState={{

--- a/src/components/__tests__/MapLibreWebGageMap.test.tsx
+++ b/src/components/__tests__/MapLibreWebGageMap.test.tsx
@@ -107,6 +107,27 @@ describe("MapLibreWebGageMap — marker filtering", () => {
 
 // ---------------------------------------------------------------------------
 
+describe("MapLibreWebGageMap — style gating", () => {
+  // Regression: with no region (e.g. a fresh incognito load before data is
+  // fetched) mapStyle was "". react-maplibre normalizes "" to null, which
+  // leaves the underlying maplibre map with no `style` object and then crashes
+  // in _updateStyleComponents (`map.style._loaded`). The component must not
+  // mount the map until it has a real style.
+  it("does not render a Map when region is undefined", () => {
+    render(
+      <MapLibreWebGageWebMap
+        gages={[]}
+        region={undefined as any}
+        onGagePress={jest.fn()}
+        singleGage={null}
+      />
+    );
+    expect(MockMap).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
 describe("MapLibreWebGageMap — startBounds", () => {
   const singleGageLngDelta = 0.00421;
   const singleGageLatDelta = 0.00922;


### PR DESCRIPTION
## Problem

On a fresh load (e.g. a new incognito window) the site showed the "Oops" error screen with:

```
TypeError: Cannot read properties of undefined (reading '_loaded')
  at MapLibreWebGageWebMap
```

## Root cause

A latent bug in `@vis.gl/react-maplibre` 8.1.0, triggered by our code:

1. On a fresh load there's no persisted MobX-State-Tree `region`, so `MapLibreWebGageMap` returned `mapStyle = ""`.
2. The library normalizes `""` → `null`.
3. maplibre-gl skips `setStyle` when the style is null (`if (resolvedOptions.style)` in the Map constructor), leaving `map.style` undefined.
4. The library's `_updateStyleComponents` reads `map.style._loaded` **without** the `map.style &&` guard its four other `_loaded` reads have → `TypeError`.

This is why it only reproduced on a fresh load: a normal session has a cached `region`, so `mapStyle` is a valid URL and `map.style` gets created.

## Fix

Don't mount `<Map>` until a real style is available (`if (!mapStyle) return null;`, placed after all hooks). Once region data loads, the component re-renders and the map mounts normally.

## Test

Added a "style gating" regression test asserting no `<Map>` is rendered when `region` is undefined — confirmed it fails before the fix and passes after. Full file suite (12 tests) passes; `tsc --noEmit` and lint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)