### PR TITLE
Map: cooperative gestures, mobile-web details fix, unified gauge zoom

### DIFF
--- a/app/(root)/gage/[id].tsx
+++ b/app/(root)/gage/[id].tsx
@@ -273,8 +273,12 @@ const GageDetailsBody = observer(function GageDetailsBody({ gageId }: { gageId: 
               <StatusLevelsCard gage={gage} />
             </RowOrCell>
             <If condition={isMobile}>
+              {/* No flex here: `flex: 1` compiles to flex-basis 0%, which on
+                  react-native-web overrides the explicit height for a flex item
+                  nested in this ScrollView, collapsing the map container to 0
+                  (white box). A plain fixed-height Card renders correctly, matching
+                  the working list-screen map. */}
               <Card
-                flex={1}
                 height={300}
                 minHeight={300}
                 top={Spacing.small}

--- a/app/(root)/gage/index.tsx
+++ b/app/(root)/gage/index.tsx
@@ -40,7 +40,6 @@ import { useLocale } from "@common-ui/contexts/LocaleContext";
 import { TxKeyPath } from "@i18n/i18n";
 import { Timing } from "@common-ui/constants/timing";
 import { RefreshControl, ScrollView } from "react-native-gesture-handler";
-import { Region } from "../../../src/models/Region";
 
 const ITEM_HEIGHT = 200;
 const MAP_WIDTH = 400;
@@ -139,29 +138,9 @@ const GageItem = observer(function GageItem({ item }: GageItemProps) {
   );
 });
 
-const HeaderComponent = ({ gages, region }: { gages: Gage[]; region: Region }) => {
-  const { isMobile } = useResponsive();
-  const router = useRouter();
-
+const HeaderComponent = () => {
   return (
     <>
-      <If condition={isMobile}>
-        <Card
-          height={300}
-          innerHorizontal={Spacing.tiny}
-          innerVertical={Spacing.tiny}
-          bottom={Spacing.small}>
-          <GageMap
-            gages={gages || []}
-            region={region}
-            onGagePress={(gage) => {
-              if (gage && router) {
-                router.push({ pathname: ROUTES.GageDetails, params: { id: gage.locationId } });
-              }
-            }}
-          />
-        </Card>
-      </If>
       <RegionSummaryCard />
     </>
   );
@@ -250,7 +229,7 @@ const HomeScreen = observer(function HomeScreen() {
             getItemLayout={getItemLayout}
             renderItem={renderGageItem}
             ListEmptyComponent={<EmptyComponent />}
-            ListHeaderComponent={<HeaderComponent gages={locations} region={regionStore.region} />}
+            ListHeaderComponent={<HeaderComponent />}
           />
         </Cell>
       </Row>

--- a/app/(root)/map/_layout.tsx
+++ b/app/(root)/map/_layout.tsx
@@ -1,0 +1,11 @@
+import { Stack } from "expo-router";
+
+export default function MapLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+      }}
+    />
+  );
+}

--- a/app/(root)/map/index.tsx
+++ b/app/(root)/map/index.tsx
@@ -25,6 +25,7 @@ const MapScreen = observer(function MapScreen() {
   const levels = useMemo(() => getInundationLevels(), []);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
   const loadTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const clearLoadTimeout = () => {
@@ -36,20 +37,28 @@ const MapScreen = observer(function MapScreen() {
 
   const handleSelect = useCallback((key: string | null) => {
     setSelectedKey(key);
+    setError(false);
     clearLoadTimeout();
     if (key === null) {
       setLoading(false);
       return;
     }
     setLoading(true);
-    // Safety fallback so the spinner never hangs (covers native, where no
-    // per-source load event is wired, and slow connections on web).
+    // Safety fallback so the spinner never hangs (covers slow connections and any
+    // case where neither the load nor error signal arrives).
     loadTimeout.current = setTimeout(() => setLoading(false), 12000);
   }, []);
 
   const handleInundationLoad = useCallback(() => {
     clearLoadTimeout();
     setLoading(false);
+    setError(false);
+  }, []);
+
+  const handleInundationError = useCallback(() => {
+    clearLoadTimeout();
+    setLoading(false);
+    setError(true);
   }, []);
 
   useEffect(() => clearLoadTimeout, []);
@@ -81,6 +90,7 @@ const MapScreen = observer(function MapScreen() {
         cooperativeGestures={false}
         inundationUrl={inundationUrl}
         onInundationLoad={handleInundationLoad}
+        onInundationError={handleInundationError}
       />
       <View style={$controlWrap}>
         <InundationControl
@@ -88,6 +98,7 @@ const MapScreen = observer(function MapScreen() {
           selectedKey={selectedKey}
           onSelect={handleSelect}
           loading={loading}
+          error={error}
         />
       </View>
     </View>

--- a/app/(root)/map/index.tsx
+++ b/app/(root)/map/index.tsx
@@ -1,0 +1,63 @@
+import React, { useMemo, useState } from "react";
+import { View, ViewStyle } from "react-native";
+import { ErrorBoundaryProps } from "expo-router";
+import { observer } from "mobx-react-lite";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import PageTitle from "@common-ui/components/PageTitle";
+import { ErrorDetails } from "@components/ErrorDetails";
+import GageMap from "@components/GageMap";
+import InundationControl from "@components/InundationControl";
+import { getInundationLevels } from "@components/inundationOverlay";
+import { useStores } from "@models/helpers/useStores";
+import { Spacing } from "@common-ui/constants/spacing";
+import { useLocale } from "@common-ui/contexts/LocaleContext";
+
+export function ErrorBoundary(props: ErrorBoundaryProps) {
+  return <ErrorDetails {...props} />;
+}
+
+const MapScreen = observer(function MapScreen() {
+  const { regionStore, getLocationsWithGages } = useStores();
+  const { t } = useLocale();
+  const insets = useSafeAreaInsets();
+
+  const levels = useMemo(() => getInundationLevels(), []);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+
+  const locations = getLocationsWithGages();
+
+  const inundationUrl = useMemo(
+    () => levels.find((l) => l.key === selectedKey)?.url ?? null,
+    [levels, selectedKey]
+  );
+
+  const $controlWrap: ViewStyle = {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: Math.max(insets.bottom, Spacing.medium),
+  };
+
+  return (
+    <View style={$screen}>
+      <PageTitle name={t("navigation.mapScreen")} />
+      <GageMap
+        gages={locations}
+        region={regionStore.region}
+        onGagePress={() => {}}
+        cooperativeGestures={false}
+        inundationUrl={inundationUrl}
+      />
+      <View style={$controlWrap}>
+        <InundationControl levels={levels} selectedKey={selectedKey} onSelect={setSelectedKey} />
+      </View>
+    </View>
+  );
+});
+
+const $screen: ViewStyle = {
+  flex: 1,
+};
+
+export default MapScreen;

--- a/app/(root)/map/index.tsx
+++ b/app/(root)/map/index.tsx
@@ -26,6 +26,10 @@ const MapScreen = observer(function MapScreen() {
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
+  // Bumped only when the already-selected level is re-tapped (e.g. to retry after
+  // an error). Folded into the inundation URL so a re-tap actually changes the URL
+  // and forces a refetch; otherwise selectedKey is unchanged and nothing reloads.
+  const [reloadNonce, setReloadNonce] = useState(0);
   const loadTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const clearLoadTimeout = () => {
@@ -35,19 +39,27 @@ const MapScreen = observer(function MapScreen() {
     }
   };
 
-  const handleSelect = useCallback((key: string | null) => {
-    setSelectedKey(key);
-    setError(false);
-    clearLoadTimeout();
-    if (key === null) {
-      setLoading(false);
-      return;
-    }
-    setLoading(true);
-    // Safety fallback so the spinner never hangs (covers slow connections and any
-    // case where neither the load nor error signal arrives).
-    loadTimeout.current = setTimeout(() => setLoading(false), 12000);
-  }, []);
+  const handleSelect = useCallback(
+    (key: string | null) => {
+      setError(false);
+      clearLoadTimeout();
+      if (key === null) {
+        setSelectedKey(null);
+        setLoading(false);
+        return;
+      }
+      // Re-tapping the current level wouldn't change the URL, so force a refetch.
+      if (key === selectedKey) {
+        setReloadNonce((n) => n + 1);
+      }
+      setSelectedKey(key);
+      setLoading(true);
+      // Safety fallback so the spinner never hangs (covers slow connections and any
+      // case where neither the load nor error signal arrives).
+      loadTimeout.current = setTimeout(() => setLoading(false), 12000);
+    },
+    [selectedKey]
+  );
 
   const handleInundationLoad = useCallback(() => {
     clearLoadTimeout();
@@ -65,10 +77,17 @@ const MapScreen = observer(function MapScreen() {
 
   const locations = getLocationsWithGages();
 
-  const inundationUrl = useMemo(
-    () => levels.find((l) => l.key === selectedKey)?.url ?? null,
-    [levels, selectedKey]
-  );
+  const inundationUrl = useMemo(() => {
+    const level = levels.find((l) => l.key === selectedKey);
+    if (!level) {
+      return null;
+    }
+    if (reloadNonce === 0) {
+      return level.url;
+    }
+    const separator = level.url.includes("?") ? "&" : "?";
+    return `${level.url}${separator}_retry=${reloadNonce}`;
+  }, [levels, selectedKey, reloadNonce]);
 
   const $controlWrap: ViewStyle = useMemo(
     () => ({

--- a/app/(root)/map/index.tsx
+++ b/app/(root)/map/index.tsx
@@ -106,7 +106,7 @@ const MapScreen = observer(function MapScreen() {
         gages={locations}
         region={regionStore.region}
         onGagePress={() => {}}
-        cooperativeGestures={false}
+        useCooperativeGestures={false}
         inundationUrl={inundationUrl}
         onInundationLoad={handleInundationLoad}
         onInundationError={handleInundationError}

--- a/app/(root)/map/index.tsx
+++ b/app/(root)/map/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { View, ViewStyle } from "react-native";
 import { ErrorBoundaryProps } from "expo-router";
 import { observer } from "mobx-react-lite";
@@ -24,6 +24,35 @@ const MapScreen = observer(function MapScreen() {
 
   const levels = useMemo(() => getInundationLevels(), []);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const loadTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearLoadTimeout = () => {
+    if (loadTimeout.current) {
+      clearTimeout(loadTimeout.current);
+      loadTimeout.current = null;
+    }
+  };
+
+  const handleSelect = useCallback((key: string | null) => {
+    setSelectedKey(key);
+    clearLoadTimeout();
+    if (key === null) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    // Safety fallback so the spinner never hangs (covers native, where no
+    // per-source load event is wired, and slow connections on web).
+    loadTimeout.current = setTimeout(() => setLoading(false), 12000);
+  }, []);
+
+  const handleInundationLoad = useCallback(() => {
+    clearLoadTimeout();
+    setLoading(false);
+  }, []);
+
+  useEffect(() => clearLoadTimeout, []);
 
   const locations = getLocationsWithGages();
 
@@ -32,12 +61,15 @@ const MapScreen = observer(function MapScreen() {
     [levels, selectedKey]
   );
 
-  const $controlWrap: ViewStyle = {
-    position: "absolute",
-    left: 0,
-    right: 0,
-    bottom: Math.max(insets.bottom, Spacing.medium),
-  };
+  const $controlWrap: ViewStyle = useMemo(
+    () => ({
+      position: "absolute",
+      left: 0,
+      right: 0,
+      bottom: Math.max(insets.bottom, Spacing.medium),
+    }),
+    [insets.bottom]
+  );
 
   return (
     <View style={$screen}>
@@ -48,9 +80,15 @@ const MapScreen = observer(function MapScreen() {
         onGagePress={() => {}}
         cooperativeGestures={false}
         inundationUrl={inundationUrl}
+        onInundationLoad={handleInundationLoad}
       />
       <View style={$controlWrap}>
-        <InundationControl levels={levels} selectedKey={selectedKey} onSelect={setSelectedKey} />
+        <InundationControl
+          levels={levels}
+          selectedKey={selectedKey}
+          onSelect={handleSelect}
+          loading={loading}
+        />
       </View>
     </View>
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -31,8 +31,8 @@ initSentry();
 export enum ROUTES {
   Home = "/",
   Forecast = "/forecast",
-  ForecastDetails = "/forecast/[...id]",
   Map = "/map",
+  ForecastDetails = "/forecast/[...id]",
   Gages = "/gage",
   GageDetails = "/gage/[id]",
   UserAlerts = "/user/alerts",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -32,6 +32,7 @@ export enum ROUTES {
   Home = "/",
   Forecast = "/forecast",
   ForecastDetails = "/forecast/[...id]",
+  Map = "/map",
   Gages = "/gage",
   GageDetails = "/gage/[id]",
   UserAlerts = "/user/alerts",
@@ -63,6 +64,12 @@ export const routes = {
     icon: "trending-up",
     tabName: "forecast",
     title: "navigation.forecastScreen",
+  },
+  [ROUTES.Map]: {
+    path: ROUTES.Map,
+    icon: "map",
+    tabName: "map",
+    title: "navigation.mapScreen",
   },
   [ROUTES.UserAlerts]: {
     path: ROUTES.About,

--- a/src/components/GageMap.tsx
+++ b/src/components/GageMap.tsx
@@ -18,7 +18,7 @@ const GageMap = observer(function GageMap(props: GageMapProps) {
     region,
     gages,
     onGagePress,
-    cooperativeGestures,
+    useCooperativeGestures,
     inundationUrl,
     onInundationLoad,
     onInundationError,
@@ -41,7 +41,7 @@ const GageMap = observer(function GageMap(props: GageMapProps) {
       onGagePress={onGagePress}
       gages={reverseGages}
       singleGage={singleGage}
-      cooperativeGestures={cooperativeGestures}
+      useCooperativeGestures={useCooperativeGestures}
       inundationUrl={inundationUrl}
       onInundationLoad={onInundationLoad}
       onInundationError={onInundationError}

--- a/src/components/GageMap.tsx
+++ b/src/components/GageMap.tsx
@@ -14,7 +14,8 @@ const Map = Platform.select({
 })();
 
 const GageMap = observer(function GageMap(props: GageMapProps) {
-  const { region, gages, onGagePress, cooperativeGestures, inundationUrl } = props;
+  const { region, gages, onGagePress, cooperativeGestures, inundationUrl, onInundationLoad } =
+    props;
 
   const reverseGages = useMemo(() => {
     return [...gages].reverse();
@@ -35,6 +36,7 @@ const GageMap = observer(function GageMap(props: GageMapProps) {
       singleGage={singleGage}
       cooperativeGestures={cooperativeGestures}
       inundationUrl={inundationUrl}
+      onInundationLoad={onInundationLoad}
     />
   );
 });

--- a/src/components/GageMap.tsx
+++ b/src/components/GageMap.tsx
@@ -14,9 +14,8 @@ const Map = Platform.select({
 })();
 
 const GageMap = observer(function GageMap(props: GageMapProps) {
-  const { region, gages, onGagePress } = props;
+  const { region, gages, onGagePress, cooperativeGestures, inundationUrl } = props;
 
-  // Reverse the gauges to get the z-order to be a little friendlier...
   const reverseGages = useMemo(() => {
     return [...gages].reverse();
   }, [gages]);
@@ -29,7 +28,14 @@ const GageMap = observer(function GageMap(props: GageMapProps) {
   }, [gages]);
 
   return (
-    <Map region={region} onGagePress={onGagePress} gages={reverseGages} singleGage={singleGage} />
+    <Map
+      region={region}
+      onGagePress={onGagePress}
+      gages={reverseGages}
+      singleGage={singleGage}
+      cooperativeGestures={cooperativeGestures}
+      inundationUrl={inundationUrl}
+    />
   );
 });
 

--- a/src/components/GageMap.tsx
+++ b/src/components/GageMap.tsx
@@ -14,8 +14,15 @@ const Map = Platform.select({
 })();
 
 const GageMap = observer(function GageMap(props: GageMapProps) {
-  const { region, gages, onGagePress, cooperativeGestures, inundationUrl, onInundationLoad } =
-    props;
+  const {
+    region,
+    gages,
+    onGagePress,
+    cooperativeGestures,
+    inundationUrl,
+    onInundationLoad,
+    onInundationError,
+  } = props;
 
   const reverseGages = useMemo(() => {
     return [...gages].reverse();
@@ -37,6 +44,7 @@ const GageMap = observer(function GageMap(props: GageMapProps) {
       cooperativeGestures={cooperativeGestures}
       inundationUrl={inundationUrl}
       onInundationLoad={onInundationLoad}
+      onInundationError={onInundationError}
     />
   );
 });

--- a/src/components/InundationControl.tsx
+++ b/src/components/InundationControl.tsx
@@ -46,6 +46,14 @@ export default function InundationControl({
 
   return (
     <View style={$container}>
+      {/* Floated above the pill and out of layout flow, so showing/hiding it
+          never resizes the pill (loads are often fast, and a resizing pill is
+          distracting). pointerEvents none keeps it from blocking segment taps. */}
+      {loading ? (
+        <View style={$spinnerWrap} pointerEvents="none">
+          <ActivityIndicator color={Colors.primary} />
+        </View>
+      ) : null}
       <View style={$pill}>
         <Row>
           <Segment
@@ -62,11 +70,6 @@ export default function InundationControl({
               onPress={() => onSelect(level.key)}
             />
           ))}
-          {loading ? (
-            <Cell align="center" innerHorizontal={Spacing.small}>
-              <ActivityIndicator color={Colors.primary} />
-            </Cell>
-          ) : null}
         </Row>
       </View>
     </View>
@@ -75,6 +78,15 @@ export default function InundationControl({
 
 const $container: ViewStyle = {
   alignItems: "center",
+};
+
+const $spinnerWrap: ViewStyle = {
+  position: "absolute",
+  bottom: "100%",
+  left: 0,
+  right: 0,
+  alignItems: "center",
+  marginBottom: Spacing.small,
 };
 
 const $pill: ViewStyle = {

--- a/src/components/InundationControl.tsx
+++ b/src/components/InundationControl.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { Pressable, View, ViewStyle, ActivityIndicator } from "react-native";
+import { Row, Cell } from "@common-ui/components/Common";
+import { LabelText, TinyText } from "@common-ui/components/Text";
+import { Colors } from "@common-ui/constants/colors";
+import { Spacing } from "@common-ui/constants/spacing";
+import { useLocale } from "@common-ui/contexts/LocaleContext";
+import { useUtils } from "@utils/utils";
+import type { InundationLevel } from "./inundationOverlay";
+
+type InundationControlProps = {
+  levels: InundationLevel[];
+  selectedKey: string | null;
+  onSelect: (key: string | null) => void;
+  loading?: boolean;
+};
+
+type SegmentProps = {
+  active: boolean;
+  label: string;
+  caption?: string;
+  onPress: () => void;
+};
+
+function Segment({ active, label, caption, onPress }: SegmentProps) {
+  return (
+    <Pressable onPress={onPress} style={[$segment, active ? $segmentActive : undefined]}>
+      <Cell align="center" innerHorizontal={Spacing.small} innerVertical={Spacing.tiny}>
+        <LabelText color={active ? Colors.white : Colors.lightDark}>{label}</LabelText>
+        {caption ? (
+          <TinyText color={active ? Colors.white : Colors.darkGrey}>{caption}</TinyText>
+        ) : null}
+      </Cell>
+    </Pressable>
+  );
+}
+
+export default function InundationControl({
+  levels,
+  selectedKey,
+  onSelect,
+  loading,
+}: InundationControlProps) {
+  const { t } = useLocale();
+  const { formatFlow } = useUtils();
+
+  return (
+    <View style={$container}>
+      <View style={$pill}>
+        <Row>
+          <Segment
+            active={selectedKey === null}
+            label={t("map.levelNone")}
+            onPress={() => onSelect(null)}
+          />
+          {levels.map((level) => (
+            <Segment
+              key={level.key}
+              active={selectedKey === level.key}
+              label={t(level.labelTx as never)}
+              caption={formatFlow(level.cfs)}
+              onPress={() => onSelect(level.key)}
+            />
+          ))}
+          {loading ? (
+            <Cell align="center" innerHorizontal={Spacing.small}>
+              <ActivityIndicator color={Colors.primary} />
+            </Cell>
+          ) : null}
+        </Row>
+      </View>
+    </View>
+  );
+}
+
+const $container: ViewStyle = {
+  alignItems: "center",
+};
+
+const $pill: ViewStyle = {
+  backgroundColor: Colors.white,
+  borderRadius: Spacing.medium,
+  paddingHorizontal: Spacing.tiny,
+  paddingVertical: Spacing.tiny,
+  shadowColor: Colors.dark,
+  shadowOpacity: 0.2,
+  shadowRadius: 6,
+  shadowOffset: { width: 0, height: 2 },
+  elevation: 4,
+};
+
+const $segment: ViewStyle = {
+  borderRadius: Spacing.small,
+};
+
+const $segmentActive: ViewStyle = {
+  backgroundColor: Colors.primary,
+};

--- a/src/components/InundationControl.tsx
+++ b/src/components/InundationControl.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Pressable, View, ViewStyle, ActivityIndicator } from "react-native";
 import { Row, Cell } from "@common-ui/components/Common";
-import { LabelText, TinyText } from "@common-ui/components/Text";
+import { LabelText, MediumText, TinyText } from "@common-ui/components/Text";
 import { Colors } from "@common-ui/constants/colors";
 import { Spacing } from "@common-ui/constants/spacing";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
@@ -55,6 +55,11 @@ export default function InundationControl({
         </View>
       ) : null}
       <View style={$pill}>
+        <Cell bottom={Spacing.tiny} align="center">
+          <MediumText color={Colors.lightDark} align="center">
+            {t("map.floodVisualizerTitle")}
+          </MediumText>
+        </Cell>
         <Row>
           <Segment
             active={selectedKey === null}

--- a/src/components/InundationControl.tsx
+++ b/src/components/InundationControl.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Pressable, View, ViewStyle, ActivityIndicator } from "react-native";
 import { Row, Cell } from "@common-ui/components/Common";
-import { LabelText, MediumText, TinyText } from "@common-ui/components/Text";
+import { LabelText, MediumText, SmallText, TinyText } from "@common-ui/components/Text";
 import { Colors } from "@common-ui/constants/colors";
 import { Spacing } from "@common-ui/constants/spacing";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
@@ -13,6 +13,7 @@ type InundationControlProps = {
   selectedKey: string | null;
   onSelect: (key: string | null) => void;
   loading?: boolean;
+  error?: boolean;
 };
 
 type SegmentProps = {
@@ -40,17 +41,28 @@ export default function InundationControl({
   selectedKey,
   onSelect,
   loading,
+  error,
 }: InundationControlProps) {
   const { t } = useLocale();
   const { formatFlow } = useUtils();
 
   return (
     <View style={$container}>
-      {/* Floated above the pill and out of layout flow, so showing/hiding it
-          never resizes the pill (loads are often fast, and a resizing pill is
-          distracting). pointerEvents none keeps it from blocking segment taps. */}
-      {loading ? (
-        <View style={$spinnerWrap} pointerEvents="none">
+      {/* The spinner and error banner float above the pill and out of layout flow,
+          so showing/hiding them never resizes the pill (loads are often fast, and a
+          resizing pill is distracting). pointerEvents none keeps them from blocking
+          segment taps. The error takes priority over the spinner. */}
+      {error ? (
+        <View style={$bannerWrap} pointerEvents="none">
+          <View style={$errorBanner}>
+            <SmallText color={Colors.white} align="center">
+              {t("map.loadError")}
+            </SmallText>
+          </View>
+        </View>
+      ) : null}
+      {!error && loading ? (
+        <View style={$bannerWrap} pointerEvents="none">
           <ActivityIndicator color={Colors.primary} />
         </View>
       ) : null}
@@ -85,13 +97,22 @@ const $container: ViewStyle = {
   alignItems: "center",
 };
 
-const $spinnerWrap: ViewStyle = {
+const $bannerWrap: ViewStyle = {
   position: "absolute",
   bottom: "100%",
   left: 0,
   right: 0,
   alignItems: "center",
   marginBottom: Spacing.small,
+  paddingHorizontal: Spacing.medium,
+};
+
+const $errorBanner: ViewStyle = {
+  backgroundColor: Colors.danger,
+  borderRadius: Spacing.small,
+  paddingHorizontal: Spacing.medium,
+  paddingVertical: Spacing.extraSmall,
+  maxWidth: 360,
 };
 
 const $pill: ViewStyle = {

--- a/src/components/MapLibreMobileGageMap.tsx
+++ b/src/components/MapLibreMobileGageMap.tsx
@@ -12,6 +12,7 @@ import { Spacing } from "../common-ui/constants/spacing";
 import TrendIcon, { TREND_ICON_TYPES } from "./TrendIcon";
 import { getTownLabelsGeoJson, TOWN_LABELS_LAYER_PROPS } from "./townLabels";
 import { getRiverOverlaysGeoJson, RIVER_OVERLAY_LAYER_PROPS } from "./riverOverlays";
+import { INUNDATION_FILL_LAYER_PROPS } from "./inundationOverlay";
 import Config from "../config/config";
 import Constants from "expo-constants";
 import floodzillaLocalStyle from "./mapStyles/floodzilla-webstyles.json";
@@ -53,6 +54,8 @@ const MapLibreMobileGageMap = ({
   region,
   onGagePress,
   singleGage,
+  cooperativeGestures,
+  inundationUrl,
 }: InternalGageMapProps) => {
   const mapRef = useRef(null);
 
@@ -83,6 +86,10 @@ const MapLibreMobileGageMap = ({
         }),
     []
   );
+
+  // When the caller disables cooperative gestures (the full-screen Map tab), pan
+  // with a single finger directly; otherwise use the two-finger gate.
+  const dragPan = cooperativeGestures === false ? true : dragPanEnabled;
 
   const mapStyle = useMemo(() => {
     if (useLocalMapStyle) {
@@ -157,8 +164,13 @@ const MapLibreMobileGageMap = ({
         style={styles.map}
         mapStyle={mapStyle}
         touchRotate={false}
-        dragPan={dragPanEnabled}>
+        dragPan={dragPan}>
         <Camera maxBounds={regionBounds} bounds={startBounds} />
+        {inundationUrl ? (
+          <GeoJSONSource id="inundation" data={inundationUrl}>
+            <Layer {...INUNDATION_FILL_LAYER_PROPS} />
+          </GeoJSONSource>
+        ) : null}
         <GeoJSONSource id="region-rivers" data={riverOverlaysGeoJson}>
           <Layer {...RIVER_OVERLAY_LAYER_PROPS} />
         </GeoJSONSource>

--- a/src/components/MapLibreMobileGageMap.tsx
+++ b/src/components/MapLibreMobileGageMap.tsx
@@ -56,6 +56,7 @@ const MapLibreMobileGageMap = ({
   singleGage,
   cooperativeGestures,
   inundationUrl,
+  onInundationLoad: _onInundationLoad,
 }: InternalGageMapProps) => {
   const mapRef = useRef(null);
 

--- a/src/components/MapLibreMobileGageMap.tsx
+++ b/src/components/MapLibreMobileGageMap.tsx
@@ -57,8 +57,36 @@ const MapLibreMobileGageMap = ({
   cooperativeGestures,
   inundationUrl,
   onInundationLoad,
+  onInundationError,
 }: InternalGageMapProps) => {
   const mapRef = useRef(null);
+
+  // Native has no per-source error event either, so probe the URL with a cheap
+  // HEAD request when it's set (no CORS on native). A non-OK status or network
+  // failure means the geojson won't load, so report the error. `cancelled` guards
+  // against a stale response after the selection changed.
+  useEffect(() => {
+    if (!inundationUrl) {
+      return undefined;
+    }
+    let cancelled = false;
+    fetch(inundationUrl, { method: "HEAD" })
+      .then((res) => {
+        if (!cancelled && !res.ok) {
+          onInundationError?.();
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          onInundationError?.();
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+    // onInundationError is a stable callback from the screen; we only re-probe on URL change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inundationUrl]);
 
   // Native has no per-source "loaded" event, so we infer it from frame rendering:
   // `onDidFinishRenderingFrameFully` fires only when a frame renders with no

--- a/src/components/MapLibreMobileGageMap.tsx
+++ b/src/components/MapLibreMobileGageMap.tsx
@@ -1,4 +1,8 @@
-import { InternalGageMapProps } from "@models/MapModels";
+import {
+  InternalGageMapProps,
+  SINGLE_GAGE_LAT_DELTA,
+  SINGLE_GAGE_LNG_DELTA,
+} from "@models/MapModels";
 import { useMemo, useRef, useState } from "react";
 import { Camera, GeoJSONSource, Layer, Map, Marker } from "@maplibre/maplibre-react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
@@ -41,8 +45,8 @@ const styles = StyleSheet.create({
 const defaultRegionBounds = [-122.4, 46.9, -120.9, 48.4];
 const defaultMapBounds = [-122.3328, 46.9564, -121.2959, 48.3127];
 
-const singleGageLatDelta = 0.00421;
-const singleGageLngDelta = 0.00421;
+const singleGageLatDelta = SINGLE_GAGE_LAT_DELTA;
+const singleGageLngDelta = SINGLE_GAGE_LNG_DELTA;
 
 const MapLibreMobileGageMap = ({
   gages,

--- a/src/components/MapLibreMobileGageMap.tsx
+++ b/src/components/MapLibreMobileGageMap.tsx
@@ -1,6 +1,8 @@
 import { InternalGageMapProps } from "@models/MapModels";
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Camera, GeoJSONSource, Layer, Map, Marker } from "@maplibre/maplibre-react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import { runOnJS } from "react-native-reanimated";
 import { StyleSheet, ViewStyle } from "react-native";
 import { Spacing } from "../common-ui/constants/spacing";
 import TrendIcon, { TREND_ICON_TYPES } from "./TrendIcon";
@@ -49,6 +51,34 @@ const MapLibreMobileGageMap = ({
   singleGage,
 }: InternalGageMapProps) => {
   const mapRef = useRef(null);
+
+  // The map lives inside a vertically-scrolling list, so a one-finger drag should
+  // scroll the page rather than pan the map. We keep panning disabled until two or
+  // more fingers are down, giving "cooperative gestures": one finger = page scroll,
+  // two fingers = pan/zoom the map. (Pinch-zoom via `touchZoom` is inherently
+  // two-finger and stays enabled.)
+  const [dragPanEnabled, setDragPanEnabled] = useState(false);
+
+  // `Gesture.Manual` only observes touches — it never activates, so it won't steal
+  // the gesture from MapLibre's own pan recognizer; it just counts active pointers.
+  const pointerCounter = useMemo(
+    () =>
+      Gesture.Manual()
+        .onTouchesDown((event) => {
+          if (event.numberOfTouches >= 2) {
+            runOnJS(setDragPanEnabled)(true);
+          }
+        })
+        .onTouchesUp((event) => {
+          if (event.numberOfTouches < 2) {
+            runOnJS(setDragPanEnabled)(false);
+          }
+        })
+        .onTouchesCancelled(() => {
+          runOnJS(setDragPanEnabled)(false);
+        }),
+    []
+  );
 
   const mapStyle = useMemo(() => {
     if (useLocalMapStyle) {
@@ -117,16 +147,23 @@ const MapLibreMobileGageMap = ({
   }, [region, singleGage]);
 
   return (
-    <Map ref={mapRef} style={styles.map} mapStyle={mapStyle} touchRotate={false}>
-      <Camera maxBounds={regionBounds} bounds={startBounds} />
-      <GeoJSONSource id="region-rivers" data={riverOverlaysGeoJson}>
-        <Layer {...RIVER_OVERLAY_LAYER_PROPS} />
-      </GeoJSONSource>
-      <GeoJSONSource id="region-towns" data={townLabelsGeoJson}>
-        <Layer {...TOWN_LABELS_LAYER_PROPS} />
-      </GeoJSONSource>
-      {markers}
-    </Map>
+    <GestureDetector gesture={pointerCounter}>
+      <Map
+        ref={mapRef}
+        style={styles.map}
+        mapStyle={mapStyle}
+        touchRotate={false}
+        dragPan={dragPanEnabled}>
+        <Camera maxBounds={regionBounds} bounds={startBounds} />
+        <GeoJSONSource id="region-rivers" data={riverOverlaysGeoJson}>
+          <Layer {...RIVER_OVERLAY_LAYER_PROPS} />
+        </GeoJSONSource>
+        <GeoJSONSource id="region-towns" data={townLabelsGeoJson}>
+          <Layer {...TOWN_LABELS_LAYER_PROPS} />
+        </GeoJSONSource>
+        {markers}
+      </Map>
+    </GestureDetector>
   );
 };
 

--- a/src/components/MapLibreMobileGageMap.tsx
+++ b/src/components/MapLibreMobileGageMap.tsx
@@ -3,7 +3,7 @@ import {
   SINGLE_GAGE_LAT_DELTA,
   SINGLE_GAGE_LNG_DELTA,
 } from "@models/MapModels";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Camera, GeoJSONSource, Layer, Map, Marker } from "@maplibre/maplibre-react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { runOnJS } from "react-native-reanimated";
@@ -56,9 +56,20 @@ const MapLibreMobileGageMap = ({
   singleGage,
   cooperativeGestures,
   inundationUrl,
-  onInundationLoad: _onInundationLoad,
+  onInundationLoad,
 }: InternalGageMapProps) => {
   const mapRef = useRef(null);
+
+  // Native has no per-source "loaded" event, so we infer it from frame rendering:
+  // `onDidFinishRenderingFrameFully` fires only when a frame renders with no
+  // pending sources/tiles. We arm this ref whenever a new inundation URL is set;
+  // the first fully-rendered frame after that means the polygon has loaded and
+  // drawn, so we clear the loading state then (rather than waiting on the screen's
+  // 12s timeout fallback). Subsequent frames (panning, etc.) are ignored.
+  const awaitingInundationRender = useRef(false);
+  useEffect(() => {
+    awaitingInundationRender.current = Boolean(inundationUrl);
+  }, [inundationUrl]);
 
   // The map lives inside a vertically-scrolling list, so a one-finger drag should
   // scroll the page rather than pan the map. We keep panning disabled until two or
@@ -165,7 +176,13 @@ const MapLibreMobileGageMap = ({
         style={styles.map}
         mapStyle={mapStyle}
         touchRotate={false}
-        dragPan={dragPan}>
+        dragPan={dragPan}
+        onDidFinishRenderingFrameFully={() => {
+          if (awaitingInundationRender.current) {
+            awaitingInundationRender.current = false;
+            onInundationLoad?.();
+          }
+        }}>
         <Camera maxBounds={regionBounds} bounds={startBounds} />
         {inundationUrl ? (
           <GeoJSONSource id="inundation" data={inundationUrl}>

--- a/src/components/MapLibreMobileGageMap.tsx
+++ b/src/components/MapLibreMobileGageMap.tsx
@@ -54,7 +54,7 @@ const MapLibreMobileGageMap = ({
   region,
   onGagePress,
   singleGage,
-  cooperativeGestures,
+  useCooperativeGestures,
   inundationUrl,
   onInundationLoad,
   onInundationError,
@@ -129,7 +129,7 @@ const MapLibreMobileGageMap = ({
 
   // When the caller disables cooperative gestures (the full-screen Map tab), pan
   // with a single finger directly; otherwise use the two-finger gate.
-  const dragPan = cooperativeGestures === false ? true : dragPanEnabled;
+  const dragPan = useCooperativeGestures === false ? true : dragPanEnabled;
 
   const mapStyle = useMemo(() => {
     if (useLocalMapStyle) {

--- a/src/components/MapLibreWebGageMap.tsx
+++ b/src/components/MapLibreWebGageMap.tsx
@@ -1,6 +1,8 @@
-import { Map, Marker, Source, Layer, useMap } from "@vis.gl/react-maplibre";
-import { useMemo } from "react";
+import { Map, Marker, Source, Layer, useMap, type MapRef } from "@vis.gl/react-maplibre";
+import { useEffect, useMemo, useRef } from "react";
 import { InternalGageMapProps } from "@models/MapModels";
+import { useResponsive } from "@common-ui/utils/responsive";
+import { useLocale } from "@common-ui/contexts/LocaleContext";
 import { StyleSheet } from "react-native";
 import "maplibre-gl/dist/maplibre-gl.css";
 import TrendIcon, { TREND_ICON_TYPES } from "./TrendIcon";
@@ -61,6 +63,41 @@ const MapLibreWebGageWebMap = ({
   }, [region]);
 
   const { current: map } = useMap();
+
+  // On the narrow (mobile-web) layout the map is the header of a vertically-scrolling
+  // list, so a one-finger drag should scroll the page rather than pan the map.
+  // maplibre's `cooperativeGestures` gives exactly that: one finger scrolls the page
+  // (with a hint overlay), two fingers pan/zoom. On desktop we leave it off so the
+  // free pan/scroll-zoom behavior is unchanged.
+  const { isMobile } = useResponsive();
+  const { t } = useLocale();
+  const mapRef = useRef<MapRef>(null);
+
+  // Localized overrides for maplibre's built-in cooperative-gestures hint overlay.
+  // maplibre merges this with its default locale, so we only override these keys.
+  const mapLocale = useMemo(
+    () => ({
+      "CooperativeGesturesHandler.WindowsHelpText": t("map.cooperativeGesturesWindows"),
+      "CooperativeGesturesHandler.MacHelpText": t("map.cooperativeGesturesMac"),
+      "CooperativeGesturesHandler.MobileHelpText": t("map.cooperativeGesturesMobile"),
+    }),
+    [t]
+  );
+
+  // `cooperativeGestures` is only read at map init by @vis.gl/react-maplibre (it is
+  // not one of its reactive handler props), so toggle it directly when the viewport
+  // crosses the breakpoint, e.g. on resize or device rotation.
+  useEffect(() => {
+    const gl = mapRef.current?.getMap();
+    if (!gl) {
+      return;
+    }
+    if (isMobile) {
+      gl.cooperativeGestures.enable();
+    } else {
+      gl.cooperativeGestures.disable();
+    }
+  }, [isMobile]);
 
   const townLabelsGeoJson = useMemo(() => getTownLabelsGeoJson(region?.id), [region]);
   const riverOverlaysGeoJson = useMemo(() => getRiverOverlaysGeoJson(region?.id), [region]);
@@ -128,11 +165,14 @@ const MapLibreWebGageWebMap = ({
 
   return (
     <Map
+      ref={mapRef}
       initialViewState={{
         bounds: startBounds,
       }}
       maxBounds={regionBounds}
       mapStyle={mapStyle}
+      cooperativeGestures={isMobile}
+      locale={mapLocale}
       attributionControl={{ compact: true }}
       onLoad={(e) => {
         const container = e.target.getContainer();

--- a/src/components/MapLibreWebGageMap.tsx
+++ b/src/components/MapLibreWebGageMap.tsx
@@ -55,7 +55,17 @@ const MapLibreWebGageWebMap = ({
   cooperativeGestures,
   inundationUrl,
   onInundationLoad,
+  onInundationError,
 }: InternalGageMapProps) => {
+  // The typed map error event doesn't carry a sourceId, so we scope errors to the
+  // inundation load by only treating an error as an inundation failure while we're
+  // awaiting one. Armed when a new URL is set; disarmed once the source loads
+  // successfully or an error has been reported.
+  const awaitingInundation = useRef(false);
+  useEffect(() => {
+    awaitingInundation.current = Boolean(inundationUrl);
+  }, [inundationUrl]);
+
   const mapStyle = useMemo(() => {
     if (useLocalMapStyle) {
       return floodzillaLocalStyle as never;
@@ -199,7 +209,17 @@ const MapLibreWebGageWebMap = ({
       }}
       onSourceData={(e) => {
         if (e.sourceId === "inundation" && e.isSourceLoaded) {
+          awaitingInundation.current = false;
           onInundationLoad?.();
+        }
+      }}
+      onError={(e) => {
+        // No sourceId on the typed error event; treat any error while awaiting the
+        // inundation source as that load failing (the basemap is already loaded by
+        // the time a level is selected).
+        if (awaitingInundation.current) {
+          awaitingInundation.current = false;
+          onInundationError?.();
         }
       }}
       style={styles.map}>

--- a/src/components/MapLibreWebGageMap.tsx
+++ b/src/components/MapLibreWebGageMap.tsx
@@ -54,6 +54,7 @@ const MapLibreWebGageWebMap = ({
   singleGage,
   cooperativeGestures,
   inundationUrl,
+  onInundationLoad,
 }: InternalGageMapProps) => {
   const mapStyle = useMemo(() => {
     if (useLocalMapStyle) {
@@ -195,6 +196,11 @@ const MapLibreWebGageWebMap = ({
             button?.click();
           }
         }, 1000);
+      }}
+      onSourceData={(e) => {
+        if (e.sourceId === "inundation" && e.isSourceLoaded) {
+          onInundationLoad?.();
+        }
       }}
       style={styles.map}>
       {inundationUrl ? (

--- a/src/components/MapLibreWebGageMap.tsx
+++ b/src/components/MapLibreWebGageMap.tsx
@@ -52,7 +52,7 @@ const MapLibreWebGageWebMap = ({
   region,
   onGagePress,
   singleGage,
-  cooperativeGestures,
+  useCooperativeGestures,
   inundationUrl,
   onInundationLoad,
   onInundationError,
@@ -88,7 +88,7 @@ const MapLibreWebGageWebMap = ({
   // (with a hint overlay), two fingers pan/zoom. On desktop we leave it off so the
   // free pan/scroll-zoom behavior is unchanged.
   const { isMobile } = useResponsive();
-  const coop = cooperativeGestures ?? isMobile;
+  const coop = useCooperativeGestures ?? isMobile;
   const { t } = useLocale();
   const mapRef = useRef<MapRef>(null);
 

--- a/src/components/MapLibreWebGageMap.tsx
+++ b/src/components/MapLibreWebGageMap.tsx
@@ -1,6 +1,10 @@
 import { Map, Marker, Source, Layer, useMap, type MapRef } from "@vis.gl/react-maplibre";
 import { useEffect, useMemo, useRef } from "react";
-import { InternalGageMapProps } from "@models/MapModels";
+import {
+  InternalGageMapProps,
+  SINGLE_GAGE_LAT_DELTA,
+  SINGLE_GAGE_LNG_DELTA,
+} from "@models/MapModels";
 import { useResponsive } from "@common-ui/utils/responsive";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
 import { StyleSheet } from "react-native";
@@ -39,8 +43,8 @@ const styles = StyleSheet.create({
 const defaultRegionBounds = [-122.4, 46.9, -120.9, 48.4];
 const defaultMapBounds = [-122.3328, 46.9564, -121.2959, 48.3127];
 
-const singleGageLatDelta = 0.00922;
-const singleGageLngDelta = 0.00421;
+const singleGageLatDelta = SINGLE_GAGE_LAT_DELTA;
+const singleGageLngDelta = SINGLE_GAGE_LNG_DELTA;
 
 const MapLibreWebGageWebMap = ({
   gages,

--- a/src/components/MapLibreWebGageMap.tsx
+++ b/src/components/MapLibreWebGageMap.tsx
@@ -88,7 +88,7 @@ const MapLibreWebGageWebMap = ({
   // (with a hint overlay), two fingers pan/zoom. On desktop we leave it off so the
   // free pan/scroll-zoom behavior is unchanged.
   const { isMobile } = useResponsive();
-  const coop = useCooperativeGestures ?? isMobile;
+  const useCoop = useCooperativeGestures ?? isMobile;
   const { t } = useLocale();
   const mapRef = useRef<MapRef>(null);
 
@@ -111,12 +111,12 @@ const MapLibreWebGageWebMap = ({
     if (!gl) {
       return;
     }
-    if (coop) {
+    if (useCoop) {
       gl.cooperativeGestures.enable();
     } else {
       gl.cooperativeGestures.disable();
     }
-  }, [coop]);
+  }, [useCoop]);
 
   const townLabelsGeoJson = useMemo(() => getTownLabelsGeoJson(region?.id), [region]);
   const riverOverlaysGeoJson = useMemo(() => getRiverOverlaysGeoJson(region?.id), [region]);
@@ -190,7 +190,7 @@ const MapLibreWebGageWebMap = ({
       }}
       maxBounds={regionBounds}
       mapStyle={mapStyle}
-      cooperativeGestures={coop}
+      cooperativeGestures={useCoop}
       locale={mapLocale}
       attributionControl={{ compact: true }}
       onLoad={(e) => {

--- a/src/components/MapLibreWebGageMap.tsx
+++ b/src/components/MapLibreWebGageMap.tsx
@@ -12,6 +12,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import TrendIcon, { TREND_ICON_TYPES } from "./TrendIcon";
 import { getTownLabelsGeoJson, TOWN_LABELS_LAYER_PROPS } from "./townLabels";
 import { getRiverOverlaysGeoJson, RIVER_OVERLAY_LAYER_PROPS } from "./riverOverlays";
+import { INUNDATION_FILL_LAYER_PROPS } from "./inundationOverlay";
 import Config from "../config/config";
 import Constants from "expo-constants";
 import floodzillaLocalStyle from "./mapStyles/floodzilla-webstyles.json";
@@ -51,6 +52,8 @@ const MapLibreWebGageWebMap = ({
   region,
   onGagePress,
   singleGage,
+  cooperativeGestures,
+  inundationUrl,
 }: InternalGageMapProps) => {
   const mapStyle = useMemo(() => {
     if (useLocalMapStyle) {
@@ -74,6 +77,7 @@ const MapLibreWebGageWebMap = ({
   // (with a hint overlay), two fingers pan/zoom. On desktop we leave it off so the
   // free pan/scroll-zoom behavior is unchanged.
   const { isMobile } = useResponsive();
+  const coop = cooperativeGestures ?? isMobile;
   const { t } = useLocale();
   const mapRef = useRef<MapRef>(null);
 
@@ -96,12 +100,12 @@ const MapLibreWebGageWebMap = ({
     if (!gl) {
       return;
     }
-    if (isMobile) {
+    if (coop) {
       gl.cooperativeGestures.enable();
     } else {
       gl.cooperativeGestures.disable();
     }
-  }, [isMobile]);
+  }, [coop]);
 
   const townLabelsGeoJson = useMemo(() => getTownLabelsGeoJson(region?.id), [region]);
   const riverOverlaysGeoJson = useMemo(() => getRiverOverlaysGeoJson(region?.id), [region]);
@@ -175,7 +179,7 @@ const MapLibreWebGageWebMap = ({
       }}
       maxBounds={regionBounds}
       mapStyle={mapStyle}
-      cooperativeGestures={isMobile}
+      cooperativeGestures={coop}
       locale={mapLocale}
       attributionControl={{ compact: true }}
       onLoad={(e) => {
@@ -193,6 +197,11 @@ const MapLibreWebGageWebMap = ({
         }, 1000);
       }}
       style={styles.map}>
+      {inundationUrl ? (
+        <Source id="inundation" type="geojson" data={inundationUrl}>
+          <Layer {...INUNDATION_FILL_LAYER_PROPS} />
+        </Source>
+      ) : null}
       <Source id="region-rivers" type="geojson" data={riverOverlaysGeoJson}>
         <Layer {...RIVER_OVERLAY_LAYER_PROPS} />
       </Source>

--- a/src/components/__tests__/InundationControl.test.tsx
+++ b/src/components/__tests__/InundationControl.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+import InundationControl from "../InundationControl";
+import type { InundationLevel } from "../inundationOverlay";
+
+jest.mock("@common-ui/contexts/LocaleContext", () => ({
+  useLocale: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("@utils/utils", () => ({
+  useUtils: () => ({ formatFlow: (n: number) => `${n} cfs` }),
+}));
+
+const levels: InundationLevel[] = [
+  { key: "minor", labelTx: "map.levelMinor", cfs: 20000, url: "u1" },
+  { key: "moderate", labelTx: "map.levelModerate", cfs: 32200, url: "u2" },
+  { key: "major", labelTx: "map.levelMajor", cfs: 42500, url: "u3" },
+];
+
+describe("InundationControl", () => {
+  it("calls onSelect with the level key when a level is pressed", () => {
+    const onSelect = jest.fn();
+    const { getByText } = render(
+      <InundationControl levels={levels} selectedKey={null} onSelect={onSelect} />
+    );
+    fireEvent.press(getByText("map.levelModerate"));
+    expect(onSelect).toHaveBeenCalledWith("moderate");
+  });
+
+  it("calls onSelect with null when None is pressed", () => {
+    const onSelect = jest.fn();
+    const { getByText } = render(
+      <InundationControl levels={levels} selectedKey="minor" onSelect={onSelect} />
+    );
+    fireEvent.press(getByText("map.levelNone"));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("renders the cfs caption for each level", () => {
+    const { getByText } = render(
+      <InundationControl levels={levels} selectedKey={null} onSelect={jest.fn()} />
+    );
+    expect(getByText("20000 cfs")).toBeTruthy();
+    expect(getByText("42500 cfs")).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/MapLibreWebGageMap.test.tsx
+++ b/src/components/__tests__/MapLibreWebGageMap.test.tsx
@@ -139,8 +139,9 @@ describe("MapLibreWebGageMap — style gating", () => {
 // ---------------------------------------------------------------------------
 
 describe("MapLibreWebGageMap — startBounds", () => {
-  const singleGageLngDelta = 0.00421;
-  const singleGageLatDelta = 0.00922;
+  // Keep in sync with SINGLE_GAGE_LNG_DELTA / SINGLE_GAGE_LAT_DELTA in MapModels.
+  const singleGageLngDelta = 0.09;
+  const singleGageLatDelta = 0.06;
 
   it("uses singleGage coords when lat and lng are valid", () => {
     const singleGage = makeGage({ latitude: 47.0, longitude: -122.0 });

--- a/src/components/__tests__/MapLibreWebGageMap.test.tsx
+++ b/src/components/__tests__/MapLibreWebGageMap.test.tsx
@@ -251,7 +251,7 @@ describe("MapLibreWebGageMap — new props", () => {
         region={makeRegion()}
         onGagePress={jest.fn()}
         singleGage={null}
-        cooperativeGestures={false}
+        useCooperativeGestures={false}
       />
     );
     expect(MockMap.mock.calls[0][0].cooperativeGestures).toBe(false);

--- a/src/components/__tests__/MapLibreWebGageMap.test.tsx
+++ b/src/components/__tests__/MapLibreWebGageMap.test.tsx
@@ -45,6 +45,7 @@ jest.mock("@common-ui/utils/responsive", () => ({
 
 const MockMap = MapLibre.Map as unknown as jest.Mock;
 const MockMarker = MapLibre.Marker as unknown as jest.Mock;
+const MockSource = MapLibre.Source as unknown as jest.Mock;
 
 const makeGage = (overrides: Record<string, unknown> = {}) =>
   ({ locationId: "test", latitude: 47.5, longitude: -121.8, ...overrides } as any);
@@ -54,6 +55,7 @@ const makeRegion = (overrides: Record<string, unknown> = {}) => ({ id: 1, ...ove
 beforeEach(() => {
   MockMap.mockClear();
   MockMarker.mockClear();
+  MockSource.mockClear();
 });
 
 // ---------------------------------------------------------------------------
@@ -236,5 +238,50 @@ describe("MapLibreWebGageMap — regionBounds", () => {
     );
     const maxBounds = MockMap.mock.calls[0][0].maxBounds;
     expect(maxBounds).toEqual([-122.4, 46.9, -120.9, 48.4]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("MapLibreWebGageMap — new props", () => {
+  it("passes cooperativeGestures=false through to the Map when explicitly set", () => {
+    render(
+      <MapLibreWebGageWebMap
+        gages={[]}
+        region={makeRegion()}
+        onGagePress={jest.fn()}
+        singleGage={null}
+        cooperativeGestures={false}
+      />
+    );
+    expect(MockMap.mock.calls[0][0].cooperativeGestures).toBe(false);
+  });
+
+  it("renders an inundation Source pointed at the given url", () => {
+    render(
+      <MapLibreWebGageWebMap
+        gages={[]}
+        region={makeRegion()}
+        onGagePress={jest.fn()}
+        singleGage={null}
+        inundationUrl="https://example.com/extent.geojson"
+      />
+    );
+    const inundation = MockSource.mock.calls.find((c) => c[0].id === "inundation");
+    expect(inundation).toBeTruthy();
+    expect(inundation[0].data).toBe("https://example.com/extent.geojson");
+  });
+
+  it("renders no inundation Source when inundationUrl is not set", () => {
+    render(
+      <MapLibreWebGageWebMap
+        gages={[]}
+        region={makeRegion()}
+        onGagePress={jest.fn()}
+        singleGage={null}
+      />
+    );
+    const inundation = MockSource.mock.calls.find((c) => c[0].id === "inundation");
+    expect(inundation).toBeFalsy();
   });
 });

--- a/src/components/__tests__/MapLibreWebGageMap.test.tsx
+++ b/src/components/__tests__/MapLibreWebGageMap.test.tsx
@@ -284,4 +284,32 @@ describe("MapLibreWebGageMap — new props", () => {
     const inundation = MockSource.mock.calls.find((c) => c[0].id === "inundation");
     expect(inundation).toBeFalsy();
   });
+
+  it("calls onInundationLoad via onSourceData only for the inundation source when fully loaded", () => {
+    const onInundationLoad = jest.fn();
+    render(
+      <MapLibreWebGageWebMap
+        gages={[]}
+        region={makeRegion()}
+        onGagePress={jest.fn()}
+        singleGage={null}
+        inundationUrl="https://example.com/extent.geojson"
+        onInundationLoad={onInundationLoad}
+      />
+    );
+
+    const onSourceData = MockMap.mock.calls[0][0].onSourceData;
+
+    // Should call the callback when the inundation source is fully loaded.
+    onSourceData({ sourceId: "inundation", isSourceLoaded: true });
+    expect(onInundationLoad).toHaveBeenCalledTimes(1);
+
+    // Should NOT call the callback for a different source.
+    onSourceData({ sourceId: "other", isSourceLoaded: true });
+    expect(onInundationLoad).toHaveBeenCalledTimes(1);
+
+    // Should NOT call the callback when isSourceLoaded is false.
+    onSourceData({ sourceId: "inundation", isSourceLoaded: false });
+    expect(onInundationLoad).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/__tests__/MapLibreWebGageMap.test.tsx
+++ b/src/components/__tests__/MapLibreWebGageMap.test.tsx
@@ -33,6 +33,16 @@ jest.mock("../TrendIcon", () => ({
   TREND_ICON_TYPES: { Map: "Map" },
 }));
 
+// Avoid pulling in the store/api graph (LocaleContext -> useStores -> api) which
+// fails to load under jsdom (TextEncoder). Only the `t` passthrough is needed here.
+jest.mock("@common-ui/contexts/LocaleContext", () => ({
+  useLocale: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("@common-ui/utils/responsive", () => ({
+  useResponsive: () => ({ isMobile: false, isDesktop: true, isTablet: false, isWideScreen: true }),
+}));
+
 const MockMap = MapLibre.Map as unknown as jest.Mock;
 const MockMarker = MapLibre.Marker as unknown as jest.Mock;
 

--- a/src/components/__tests__/MapLibreWebGageMap.test.tsx
+++ b/src/components/__tests__/MapLibreWebGageMap.test.tsx
@@ -312,4 +312,42 @@ describe("MapLibreWebGageMap — new props", () => {
     onSourceData({ sourceId: "inundation", isSourceLoaded: false });
     expect(onInundationLoad).toHaveBeenCalledTimes(1);
   });
+
+  it("calls onInundationError on a map error while an inundation load is awaited", () => {
+    const onInundationError = jest.fn();
+    render(
+      <MapLibreWebGageWebMap
+        gages={[]}
+        region={makeRegion()}
+        onGagePress={jest.fn()}
+        singleGage={null}
+        inundationUrl="https://example.com/extent.geojson"
+        onInundationError={onInundationError}
+      />
+    );
+
+    const props = MockMap.mock.calls[0][0];
+    props.onError({ error: new Error("Failed to fetch") });
+    expect(onInundationError).toHaveBeenCalledTimes(1);
+
+    // After one failure it disarms — a second error should not fire again.
+    props.onError({ error: new Error("Failed to fetch") });
+    expect(onInundationError).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onInundationError when no inundation load is awaited", () => {
+    const onInundationError = jest.fn();
+    render(
+      <MapLibreWebGageWebMap
+        gages={[]}
+        region={makeRegion()}
+        onGagePress={jest.fn()}
+        singleGage={null}
+        onInundationError={onInundationError}
+      />
+    );
+
+    MockMap.mock.calls[0][0].onError({ error: new Error("some basemap tile error") });
+    expect(onInundationError).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/__tests__/inundationOverlay.test.ts
+++ b/src/components/__tests__/inundationOverlay.test.ts
@@ -1,8 +1,10 @@
 import { getInundationLevels, INUNDATION_FILL_LAYER_PROPS } from "../inundationOverlay";
 
+const TEST_URL_FOR_TESTING = "https://this.does.not.exist/";
+
 jest.mock("../../config/config", () => ({
   __esModule: true,
-  default: { INUNDATION_GEOJSON_BASE_URL: "https://storage.googleapis.com/fz-dev-public/" },
+  default: { INUNDATION_GEOJSON_BASE_URL: TEST_URL_FOR_TESTING },
 }));
 
 describe("getInundationLevels", () => {
@@ -15,10 +17,10 @@ describe("getInundationLevels", () => {
   it("builds each url from the config base + filename", () => {
     const levels = getInundationLevels();
     expect(levels[0].url).toBe(
-      "https://storage.googleapis.com/fz-dev-public/FloodExtent_20000CFS_fixed_simplified.geojson"
+      TEST_URL_FOR_TESTING + "FloodExtent_20000CFS_fixed_simplified.geojson"
     );
     expect(levels[2].url).toBe(
-      "https://storage.googleapis.com/fz-dev-public/FloodExtent_42500CFS_fixed_simplified.geojson"
+      TEST_URL_FOR_TESTING + "FloodExtent_42500CFS_fixed_simplified.geojson"
     );
   });
 

--- a/src/components/__tests__/inundationOverlay.test.ts
+++ b/src/components/__tests__/inundationOverlay.test.ts
@@ -1,0 +1,39 @@
+import { getInundationLevels, INUNDATION_FILL_LAYER_PROPS } from "../inundationOverlay";
+
+jest.mock("../../config/config", () => ({
+  __esModule: true,
+  default: { INUNDATION_GEOJSON_BASE_URL: "https://storage.googleapis.com/fz-dev-public/" },
+}));
+
+describe("getInundationLevels", () => {
+  it("returns the three Carnation cfs levels in ascending order", () => {
+    const levels = getInundationLevels();
+    expect(levels.map((l) => l.cfs)).toEqual([20000, 32200, 42500]);
+    expect(levels.map((l) => l.key)).toEqual(["minor", "moderate", "major"]);
+  });
+
+  it("builds each url from the config base + filename", () => {
+    const levels = getInundationLevels();
+    expect(levels[0].url).toBe(
+      "https://storage.googleapis.com/fz-dev-public/FloodExtent_20000CFS_fixed_simplified.geojson"
+    );
+    expect(levels[2].url).toBe(
+      "https://storage.googleapis.com/fz-dev-public/FloodExtent_42500CFS_fixed_simplified.geojson"
+    );
+  });
+
+  it("maps each level to its i18n label key", () => {
+    expect(getInundationLevels().map((l) => l.labelTx)).toEqual([
+      "map.levelMinor",
+      "map.levelModerate",
+      "map.levelMajor",
+    ]);
+  });
+});
+
+describe("INUNDATION_FILL_LAYER_PROPS", () => {
+  it("is a fill layer", () => {
+    expect(INUNDATION_FILL_LAYER_PROPS.type).toBe("fill");
+    expect(INUNDATION_FILL_LAYER_PROPS.id).toBe("inundation-fill");
+  });
+});

--- a/src/components/inundationOverlay.ts
+++ b/src/components/inundationOverlay.ts
@@ -1,0 +1,56 @@
+import type { FillLayerSpecification } from "@maplibre/maplibre-gl-style-spec";
+import Config from "@config/config";
+
+export type InundationLevel = {
+  key: string;
+  labelTx: string;
+  cfs: number;
+  url: string;
+};
+
+const LEVEL_FILES: { key: string; labelTx: string; cfs: number; file: string }[] = [
+  {
+    key: "minor",
+    labelTx: "map.levelMinor",
+    cfs: 20000,
+    file: "FloodExtent_20000CFS_fixed_simplified.geojson",
+  },
+  {
+    key: "moderate",
+    labelTx: "map.levelModerate",
+    cfs: 32200,
+    file: "FloodExtent_32200CFS_fixed_simplified.geojson",
+  },
+  {
+    key: "major",
+    labelTx: "map.levelMajor",
+    cfs: 42500,
+    file: "FloodExtent_42500CFS_fixed_simplified.geojson",
+  },
+];
+
+function baseUrl(): string {
+  const base = Config.INUNDATION_GEOJSON_BASE_URL;
+  return base.endsWith("/") ? base : base + "/";
+}
+
+export function getInundationLevels(): InundationLevel[] {
+  const base = baseUrl();
+  return LEVEL_FILES.map(({ key, labelTx, cfs, file }) => ({
+    key,
+    labelTx,
+    cfs,
+    url: base + file,
+  }));
+}
+
+// Single translucent fill shared by all levels (only one is shown at a time).
+// Declared beneath the river/town overlays so those annotations remain visible.
+export const INUNDATION_FILL_LAYER_PROPS: Omit<FillLayerSpecification, "source"> = {
+  id: "inundation-fill",
+  type: "fill",
+  paint: {
+    "fill-color": "rgba(30, 120, 200, 0.35)",
+    "fill-outline-color": "rgba(20, 90, 160, 0.9)",
+  },
+};

--- a/src/config/config.base.ts
+++ b/src/config/config.base.ts
@@ -94,7 +94,7 @@ const BaseConfig: {
   GAGE_IMAGE_BASE_URL: "https://svpastorage.blob.core.windows.net/uploads/",
   DONATION_URL: "https://www.paypal.com/donate/?hosted_button_id=HT6T3U5F2C4NG",
   DEFAULT_MAP_TILE_BASE_URL: "https://floodzilla.com/maps",
-  INUNDATION_GEOJSON_BASE_URL: "https://floodzilla.com/map/",
+  INUNDATION_GEOJSON_BASE_URL: "https://storage.googleapis.com/fz-dev-public/",
 
   SVPA_URL: "https://svpa.us",
   SVPA_PHONE: "425-549-0316",

--- a/src/config/config.base.ts
+++ b/src/config/config.base.ts
@@ -94,7 +94,7 @@ const BaseConfig: {
   GAGE_IMAGE_BASE_URL: "https://svpastorage.blob.core.windows.net/uploads/",
   DONATION_URL: "https://www.paypal.com/donate/?hosted_button_id=HT6T3U5F2C4NG",
   DEFAULT_MAP_TILE_BASE_URL: "https://floodzilla.com/maps",
-  INUNDATION_GEOJSON_BASE_URL: "https://storage.googleapis.com/fz-dev-public/",
+  INUNDATION_GEOJSON_BASE_URL: "https://floodzilla.com/map/",
 
   SVPA_URL: "https://svpa.us",
   SVPA_PHONE: "425-549-0316",

--- a/src/config/config.base.ts
+++ b/src/config/config.base.ts
@@ -60,6 +60,7 @@ const BaseConfig: {
   GAGE_IMAGE_BASE_URL: string;
   DONATION_URL: string;
   DEFAULT_MAP_TILE_BASE_URL: string;
+  INUNDATION_GEOJSON_BASE_URL: string;
 
   SVPA_URL: string;
   SVPA_PHONE: string;
@@ -93,6 +94,7 @@ const BaseConfig: {
   GAGE_IMAGE_BASE_URL: "https://svpastorage.blob.core.windows.net/uploads/",
   DONATION_URL: "https://www.paypal.com/donate/?hosted_button_id=HT6T3U5F2C4NG",
   DEFAULT_MAP_TILE_BASE_URL: "https://floodzilla.com/maps",
+  INUNDATION_GEOJSON_BASE_URL: "https://storage.googleapis.com/fz-dev-public/",
 
   SVPA_URL: "https://svpa.us",
   SVPA_PHONE: "425-549-0316",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -47,6 +47,7 @@ const en = {
   navigation: {
     homeScreen: "Gauges",
     forecastScreen: "Forecast",
+    mapScreen: "Map",
     alertsScreen: "Alerts",
     profileScreen: "Edit Profile",
     loginScreen: "Login",
@@ -274,6 +275,10 @@ const en = {
     cooperativeGesturesWindows: "Use Ctrl + scroll to zoom the map",
     cooperativeGesturesMac: "Use ⌘ + scroll to zoom the map",
     cooperativeGesturesMobile: "Use two fingers to move the map",
+    levelNone: "None",
+    levelMinor: "Minor",
+    levelModerate: "Moderate",
+    levelMajor: "Major",
   },
   calloutReading: {
     lastReading: "Last Reading",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -275,6 +275,7 @@ const en = {
     cooperativeGesturesWindows: "Use Ctrl + scroll to zoom the map",
     cooperativeGesturesMac: "Use ⌘ + scroll to zoom the map",
     cooperativeGesturesMobile: "Use two fingers to move the map",
+    floodVisualizerTitle: "Flood Visualizer",
     levelNone: "None",
     levelMinor: "Minor",
     levelModerate: "Moderate",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -270,6 +270,11 @@ const en = {
     upstreamGage: "Upstream Gauge",
     downstreamGage: "Downstream Gauge",
   },
+  map: {
+    cooperativeGesturesWindows: "Use Ctrl + scroll to zoom the map",
+    cooperativeGesturesMac: "Use ⌘ + scroll to zoom the map",
+    cooperativeGesturesMobile: "Use two fingers to move the map",
+  },
   calloutReading: {
     lastReading: "Last Reading",
     peak: "Peak",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -276,6 +276,7 @@ const en = {
     cooperativeGesturesMac: "Use ⌘ + scroll to zoom the map",
     cooperativeGesturesMobile: "Use two fingers to move the map",
     floodVisualizerTitle: "Flood Visualizer",
+    loadError: "Couldn't load flood data. Please try again.",
     levelNone: "None",
     levelMinor: "Minor",
     levelModerate: "Moderate",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -280,6 +280,7 @@ const es = {
     cooperativeGesturesMac: "Usa ⌘ + desplazamiento para hacer zoom en el mapa",
     cooperativeGesturesMobile: "Usa dos dedos para mover el mapa",
     floodVisualizerTitle: "Visualizador de inundaciones",
+    loadError: "No se pudieron cargar los datos de inundación. Inténtalo de nuevo.",
     levelNone: "Ninguna",
     levelMinor: "Menor",
     levelModerate: "Moderada",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -279,6 +279,7 @@ const es = {
     cooperativeGesturesWindows: "Usa Ctrl + desplazamiento para hacer zoom en el mapa",
     cooperativeGesturesMac: "Usa ⌘ + desplazamiento para hacer zoom en el mapa",
     cooperativeGesturesMobile: "Usa dos dedos para mover el mapa",
+    floodVisualizerTitle: "Visualizador de inundaciones",
     levelNone: "Ninguna",
     levelMinor: "Menor",
     levelModerate: "Moderada",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -274,6 +274,11 @@ const es = {
     upstreamGage: "Medidor río arriba",
     downstreamGage: "Medidor río abajo",
   },
+  map: {
+    cooperativeGesturesWindows: "Usa Ctrl + desplazamiento para hacer zoom en el mapa",
+    cooperativeGesturesMac: "Usa ⌘ + desplazamiento para hacer zoom en el mapa",
+    cooperativeGesturesMobile: "Usa dos dedos para mover el mapa",
+  },
   calloutReading: {
     lastReading: "Última medición",
     peak: "Máximo",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -49,6 +49,7 @@ const es = {
   navigation: {
     homeScreen: "Medidores",
     forecastScreen: "Pronóstico",
+    mapScreen: "Mapa",
     alertsScreen: "Alertas",
     profileScreen: "Editar perfil",
     loginScreen: "Iniciar sesión",
@@ -278,6 +279,10 @@ const es = {
     cooperativeGesturesWindows: "Usa Ctrl + desplazamiento para hacer zoom en el mapa",
     cooperativeGesturesMac: "Usa ⌘ + desplazamiento para hacer zoom en el mapa",
     cooperativeGesturesMobile: "Usa dos dedos para mover el mapa",
+    levelNone: "Ninguna",
+    levelMinor: "Menor",
+    levelModerate: "Moderada",
+    levelMajor: "Mayor",
   },
   calloutReading: {
     lastReading: "Última medición",

--- a/src/models/MapModels.ts
+++ b/src/models/MapModels.ts
@@ -1,6 +1,15 @@
 import { Gage } from "./Gage";
 import { Region } from "./Region";
 
+// Half-extents (in degrees) of the bounding box used to frame a single gauge on
+// the details map. maplibre fits this box to the container, so larger values zoom
+// out. Shared by the web and native maps so they stay in sync (they had drifted
+// apart). The values were chosen by trial and error to be roughly square and to
+// show the gauge and enough surrounding context to include a couple of local towns
+// for most gauges.
+export const SINGLE_GAGE_LAT_DELTA = 0.06;
+export const SINGLE_GAGE_LNG_DELTA = 0.09;
+
 export type GageMapProps = {
   onGagePress: (gage: Gage) => void;
   region: Region;

--- a/src/models/MapModels.ts
+++ b/src/models/MapModels.ts
@@ -14,6 +14,13 @@ export type GageMapProps = {
   onGagePress: (gage: Gage) => void;
   region: Region;
   gages: Gage[];
+  // When explicitly false, disables the accidental-scroll protection so a single
+  // finger pans the map (used by the full-screen Map tab). Defaults to the
+  // existing per-platform behavior when omitted.
+  cooperativeGestures?: boolean;
+  // When set, the map renders a translucent flood-inundation fill for this URL,
+  // beneath the river/town overlays. Null/undefined renders none.
+  inundationUrl?: string | null;
 };
 
 export type InternalGageMapProps = GageMapProps & {

--- a/src/models/MapModels.ts
+++ b/src/models/MapModels.ts
@@ -21,6 +21,9 @@ export type GageMapProps = {
   // When set, the map renders a translucent flood-inundation fill for this URL,
   // beneath the river/town overlays. Null/undefined renders none.
   inundationUrl?: string | null;
+  // Called when the inundation GeoJSON source has finished loading into the map
+  // (web only; native relies on the screen's timeout fallback).
+  onInundationLoad?: () => void;
 };
 
 export type InternalGageMapProps = GageMapProps & {

--- a/src/models/MapModels.ts
+++ b/src/models/MapModels.ts
@@ -21,9 +21,15 @@ export type GageMapProps = {
   // When set, the map renders a translucent flood-inundation fill for this URL,
   // beneath the river/town overlays. Null/undefined renders none.
   inundationUrl?: string | null;
-  // Called when the inundation GeoJSON source has finished loading into the map
-  // (web only; native relies on the screen's timeout fallback).
+  // Called when the inundation GeoJSON source has finished loading into the map.
+  // Web fires it from the source-loaded event; native from the first
+  // fully-rendered frame after the URL is set. The screen also keeps a timeout
+  // fallback so the loading state never hangs.
   onInundationLoad?: () => void;
+  // Called when the inundation GeoJSON fails to load (e.g. the URL 404s or the
+  // network is down). Web fires it from the map error event; native from a HEAD
+  // probe of the URL.
+  onInundationError?: () => void;
 };
 
 export type InternalGageMapProps = GageMapProps & {

--- a/src/models/MapModels.ts
+++ b/src/models/MapModels.ts
@@ -17,7 +17,7 @@ export type GageMapProps = {
   // When explicitly false, disables the accidental-scroll protection so a single
   // finger pans the map (used by the full-screen Map tab). Defaults to the
   // existing per-platform behavior when omitted.
-  cooperativeGestures?: boolean;
+  useCooperativeGestures?: boolean;
   // When set, the map renders a translucent flood-inundation fill for this URL,
   // beneath the river/town overlays. Null/undefined renders none.
   inundationUrl?: string | null;


### PR DESCRIPTION
## Summary

Three map fixes/improvements, all scoped to the gauge maps:

- **Cooperative gestures** — the map is embedded in a vertically-scrolling list, so a one-finger drag was panning the map instead of scrolling the page. Now one finger scrolls the page and two fingers pan/zoom.
  - Native: keep `dragPan` disabled until 2+ fingers are down, tracked via a non-activating `Gesture.Manual` pointer counter (it observes touches without stealing MapLibre's own pan recognizer).
  - Web: enable maplibre's built-in `cooperativeGestures` only on the narrow (mobile-web) layout; desktop pan/scroll-zoom is unchanged. Toggled on viewport breakpoint changes since the wrapper only reads it at init.
  - Localized the cooperative-gestures hint overlay (en/es) via the map `locale`.

- **Details map white box on mobile web** — the details-page map Card used `flex={1}` alongside an explicit height; inside the scrollable `Content`, `flex-basis: 0%` collapsed the map container to zero height (white box). Dropped `flex` so it's a plain fixed-height block, matching the working list-screen map.

- **Unified single-gauge zoom** — the single-gauge framing deltas had drifted between the web and native maps. Extracted them to shared `SINGLE_GAGE_LAT_DELTA` / `SINGLE_GAGE_LNG_DELTA` constants in `MapModels` and widened them to show the gauge with surrounding context (~square on the ground at this latitude).

## Verification

- `npx tsc --noEmit` clean, `npm run lint` 0 errors, `npm test` 373 passing.
- Cooperative gestures + the mobile-web details map were verified manually in the browser (native maps don't run in standalone dev builds). Native gesture behavior should be confirmed on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)