### PR TITLE
feat(map): road-closure overlay + remote region-keyed level config

### DIFF
--- a/app/(root)/map/index.tsx
+++ b/app/(root)/map/index.tsx
@@ -8,7 +8,7 @@ import PageTitle from "@common-ui/components/PageTitle";
 import { ErrorDetails } from "@components/ErrorDetails";
 import GageMap from "@components/GageMap";
 import InundationControl from "@components/InundationControl";
-import { getInundationLevels } from "@components/inundationOverlay";
+import { useInundationLevels } from "@components/useInundationLevels";
 import { useStores } from "@models/helpers/useStores";
 import { Spacing } from "@common-ui/constants/spacing";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
@@ -22,7 +22,7 @@ const MapScreen = observer(function MapScreen() {
   const { t } = useLocale();
   const insets = useSafeAreaInsets();
 
-  const levels = useMemo(() => getInundationLevels(), []);
+  const { levels, ready } = useInundationLevels(regionStore.region?.id);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
@@ -78,7 +78,7 @@ const MapScreen = observer(function MapScreen() {
   const locations = getLocationsWithGages();
 
   const inundationUrl = useMemo(() => {
-    const level = levels.find((l) => l.key === selectedKey);
+    const level = levels?.find((l) => l.key === selectedKey);
     if (!level) {
       return null;
     }
@@ -88,6 +88,11 @@ const MapScreen = observer(function MapScreen() {
     const separator = level.url.includes("?") ? "&" : "?";
     return `${level.url}${separator}_retry=${reloadNonce}`;
   }, [levels, selectedKey, reloadNonce]);
+
+  const roadClosuresUrl = useMemo(() => {
+    const level = levels?.find((l) => l.key === selectedKey);
+    return level?.roadClosuresUrl ?? null;
+  }, [levels, selectedKey]);
 
   const $controlWrap: ViewStyle = useMemo(
     () => ({
@@ -110,16 +115,21 @@ const MapScreen = observer(function MapScreen() {
         inundationUrl={inundationUrl}
         onInundationLoad={handleInundationLoad}
         onInundationError={handleInundationError}
+        roadClosuresUrl={roadClosuresUrl}
       />
-      <View style={$controlWrap}>
-        <InundationControl
-          levels={levels}
-          selectedKey={selectedKey}
-          onSelect={handleSelect}
-          loading={loading}
-          error={error}
-        />
-      </View>
+      {/* Only show the Flood Visualizer once the region's level config has loaded
+          and actually has levels — no config (404) means no control at all. */}
+      {ready && levels && levels.length > 0 ? (
+        <View style={$controlWrap}>
+          <InundationControl
+            levels={levels}
+            selectedKey={selectedKey}
+            onSelect={handleSelect}
+            loading={loading}
+            error={error}
+          />
+        </View>
+      ) : null}
     </View>
   );
 });

--- a/src/common-ui/contexts/LocaleContext.tsx
+++ b/src/common-ui/contexts/LocaleContext.tsx
@@ -21,7 +21,7 @@ const LocaleContext = React.createContext<LocaleContextType>(initialState);
 export const useLocaleContext = () => React.useContext(LocaleContext);
 
 export const useLocale = () => {
-  const { t, changeContextLocale } = useLocaleContext();
+  const { t, changeContextLocale, locale } = useLocaleContext();
   const { authSessionStore } = useStores();
 
   const changeLocale = (locale: string) => {
@@ -30,7 +30,7 @@ export const useLocale = () => {
     authSessionStore.setPrefferedLocale(locale);
   };
 
-  return { t, changeLocale };
+  return { t, changeLocale, locale };
 };
 
 export const LocaleProvider = ({ children }: { children: React.ReactNode }) => {

--- a/src/components/GageMap.tsx
+++ b/src/components/GageMap.tsx
@@ -22,6 +22,7 @@ const GageMap = observer(function GageMap(props: GageMapProps) {
     inundationUrl,
     onInundationLoad,
     onInundationError,
+    roadClosuresUrl,
   } = props;
 
   const reverseGages = useMemo(() => {
@@ -45,6 +46,7 @@ const GageMap = observer(function GageMap(props: GageMapProps) {
       inundationUrl={inundationUrl}
       onInundationLoad={onInundationLoad}
       onInundationError={onInundationError}
+      roadClosuresUrl={roadClosuresUrl}
     />
   );
 });

--- a/src/components/InundationControl.tsx
+++ b/src/components/InundationControl.tsx
@@ -6,7 +6,7 @@ import { Colors } from "@common-ui/constants/colors";
 import { Spacing } from "@common-ui/constants/spacing";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
 import { useUtils } from "@utils/utils";
-import type { InundationLevel } from "./inundationOverlay";
+import { localizeLevelLabel, type InundationLevel } from "./inundationOverlay";
 
 type InundationControlProps = {
   levels: InundationLevel[];
@@ -43,7 +43,7 @@ export default function InundationControl({
   loading,
   error,
 }: InundationControlProps) {
-  const { t } = useLocale();
+  const { t, locale } = useLocale();
   const { formatFlow } = useUtils();
 
   return (
@@ -82,7 +82,7 @@ export default function InundationControl({
             <Segment
               key={level.key}
               active={selectedKey === level.key}
-              label={t(level.labelTx as never)}
+              label={localizeLevelLabel(level.label, locale)}
               caption={formatFlow(level.cfs)}
               onPress={() => onSelect(level.key)}
             />

--- a/src/components/InundationControl.tsx
+++ b/src/components/InundationControl.tsx
@@ -1,7 +1,15 @@
-import React from "react";
-import { Pressable, View, ViewStyle, ActivityIndicator } from "react-native";
+import React, { useState } from "react";
+import { Modal, Pressable, ScrollView, View, ViewStyle, ActivityIndicator } from "react-native";
 import { Row, Cell } from "@common-ui/components/Common";
-import { LabelText, MediumText, SmallText, TinyText } from "@common-ui/components/Text";
+import Icon from "@common-ui/components/Icon";
+import {
+  LabelText,
+  MediumText,
+  RegularText,
+  SmallText,
+  SmallTitle,
+  TinyText,
+} from "@common-ui/components/Text";
 import { Colors } from "@common-ui/constants/colors";
 import { Spacing } from "@common-ui/constants/spacing";
 import { useLocale } from "@common-ui/contexts/LocaleContext";
@@ -36,6 +44,19 @@ function Segment({ active, label, caption, onPress }: SegmentProps) {
   );
 }
 
+// One row of the road-color legend: a short colored line swatch matching the
+// map's road-closure colors, followed by its meaning.
+function RoadLegendRow({ color, text }: { color: string; text: string }) {
+  return (
+    <Row top={Spacing.extraSmall}>
+      <View style={[$roadSwatch, { backgroundColor: color }]} />
+      <Cell flex left={Spacing.small}>
+        <SmallText color={Colors.lightDark}>{text}</SmallText>
+      </Cell>
+    </Row>
+  );
+}
+
 export default function InundationControl({
   levels,
   selectedKey,
@@ -45,6 +66,7 @@ export default function InundationControl({
 }: InundationControlProps) {
   const { t, locale } = useLocale();
   const { formatFlow } = useUtils();
+  const [infoVisible, setInfoVisible] = useState(false);
 
   return (
     <View style={$container}>
@@ -67,11 +89,19 @@ export default function InundationControl({
         </View>
       ) : null}
       <View style={$pill}>
-        <Cell bottom={Spacing.tiny} align="center">
+        <Row align="center" bottom={Spacing.tiny}>
           <MediumText color={Colors.lightDark} align="center">
             {t("map.floodVisualizerTitle")}
           </MediumText>
-        </Cell>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={t("map.info.buttonLabel")}
+            hitSlop={Spacing.small}
+            onPress={() => setInfoVisible(true)}
+            style={$infoButton}>
+            <Icon name="info" size={Spacing.medium} color={Colors.darkGrey} />
+          </Pressable>
+        </Row>
         <Row>
           <Segment
             active={selectedKey === null}
@@ -89,6 +119,55 @@ export default function InundationControl({
           ))}
         </Row>
       </View>
+
+      <Modal
+        visible={infoVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setInfoVisible(false)}>
+        <Pressable style={$infoOverlay} onPress={() => setInfoVisible(false)}>
+          {/* Stop propagation so taps inside the card don't dismiss the modal. */}
+          <Pressable style={$infoCard} onPress={() => {}}>
+            <Row align="space-between" bottom={Spacing.small}>
+              <Cell flex right={Spacing.small}>
+                <SmallTitle color={Colors.lightDark}>{t("map.info.title")}</SmallTitle>
+              </Cell>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={t("map.info.close")}
+                hitSlop={Spacing.small}
+                onPress={() => setInfoVisible(false)}>
+                <Icon name="x" size={Spacing.large} color={Colors.darkGrey} />
+              </Pressable>
+            </Row>
+            <ScrollView
+              style={$infoScroll}
+              showsVerticalScrollIndicator={false}
+              contentContainerStyle={$infoScrollContent}>
+              <RegularText color={Colors.lightDark}>{t("map.info.intro")}</RegularText>
+              <Cell top={Spacing.small}>
+                <RegularText color={Colors.lightDark}>{t("map.info.extent")}</RegularText>
+              </Cell>
+              <Cell top={Spacing.small}>
+                <RegularText color={Colors.lightDark}>{t("map.info.cfs")}</RegularText>
+              </Cell>
+              <Cell top={Spacing.small}>
+                <RegularText color={Colors.lightDark}>{t("map.info.modeled")}</RegularText>
+              </Cell>
+
+              <Cell top={Spacing.medium}>
+                <MediumText color={Colors.lightDark}>{t("map.info.roadsHeading")}</MediumText>
+              </Cell>
+              <RoadLegendRow color={Colors.success} text={t("map.info.roadOpen")} />
+              <RoadLegendRow color={Colors.warning} text={t("map.info.roadPossible")} />
+              <RoadLegendRow color={Colors.danger} text={t("map.info.roadClosed")} />
+              <Cell top={Spacing.medium}>
+                <RegularText color={Colors.darkGrey}>{t("map.info.roadsNote")}</RegularText>
+              </Cell>
+            </ScrollView>
+          </Pressable>
+        </Pressable>
+      </Modal>
     </View>
   );
 }
@@ -127,10 +206,46 @@ const $pill: ViewStyle = {
   elevation: 4,
 };
 
+const $infoButton: ViewStyle = {
+  marginLeft: Spacing.tiny,
+};
+
 const $segment: ViewStyle = {
   borderRadius: Spacing.small,
 };
 
 const $segmentActive: ViewStyle = {
   backgroundColor: Colors.primary,
+};
+
+const $infoOverlay: ViewStyle = {
+  flex: 1,
+  backgroundColor: "rgba(0,0,0,0.4)",
+  justifyContent: "center",
+  alignItems: "center",
+  padding: Spacing.medium,
+};
+
+const $infoCard: ViewStyle = {
+  backgroundColor: Colors.white,
+  borderRadius: Spacing.medium,
+  padding: Spacing.large,
+  maxWidth: 420,
+  width: "100%",
+  maxHeight: "80%",
+};
+
+const $infoScroll: ViewStyle = {
+  flexShrink: 1,
+};
+
+const $infoScrollContent: ViewStyle = {
+  paddingBottom: Spacing.tiny,
+};
+
+const $roadSwatch: ViewStyle = {
+  width: Spacing.large,
+  height: Spacing.tiny,
+  borderRadius: Spacing.micro,
+  marginTop: Spacing.micro,
 };

--- a/src/components/MapLibreMobileGageMap.tsx
+++ b/src/components/MapLibreMobileGageMap.tsx
@@ -231,7 +231,10 @@ const MapLibreMobileGageMap = ({
         <GeoJSONSource id="region-towns" data={townLabelsGeoJson}>
           <Layer {...TOWN_LABELS_LAYER_PROPS} />
         </GeoJSONSource>
-        {markers}
+        {/* Hide gauge icons while a flood level is selected so users aren't
+            confused about whether the icons reflect live status or the
+            selected visualization level. */}
+        {inundationUrl ? null : markers}
       </Map>
     </GestureDetector>
   );

--- a/src/components/MapLibreMobileGageMap.tsx
+++ b/src/components/MapLibreMobileGageMap.tsx
@@ -13,6 +13,7 @@ import TrendIcon, { TREND_ICON_TYPES } from "./TrendIcon";
 import { getTownLabelsGeoJson, TOWN_LABELS_LAYER_PROPS } from "./townLabels";
 import { getRiverOverlaysGeoJson, RIVER_OVERLAY_LAYER_PROPS } from "./riverOverlays";
 import { INUNDATION_FILL_LAYER_PROPS } from "./inundationOverlay";
+import { ROAD_CLOSURE_LINE_LAYER_PROPS, ROAD_CLOSURE_LABEL_LAYER_PROPS } from "./roadClosures";
 import Config from "../config/config";
 import Constants from "expo-constants";
 import floodzillaLocalStyle from "./mapStyles/floodzilla-webstyles.json";
@@ -58,6 +59,7 @@ const MapLibreMobileGageMap = ({
   inundationUrl,
   onInundationLoad,
   onInundationError,
+  roadClosuresUrl,
 }: InternalGageMapProps) => {
   const mapRef = useRef(null);
 
@@ -215,6 +217,12 @@ const MapLibreMobileGageMap = ({
         {inundationUrl ? (
           <GeoJSONSource id="inundation" data={inundationUrl}>
             <Layer {...INUNDATION_FILL_LAYER_PROPS} />
+          </GeoJSONSource>
+        ) : null}
+        {roadClosuresUrl ? (
+          <GeoJSONSource id="road-closures" data={roadClosuresUrl}>
+            <Layer {...ROAD_CLOSURE_LINE_LAYER_PROPS} />
+            <Layer {...ROAD_CLOSURE_LABEL_LAYER_PROPS} />
           </GeoJSONSource>
         ) : null}
         <GeoJSONSource id="region-rivers" data={riverOverlaysGeoJson}>

--- a/src/components/MapLibreWebGageMap.tsx
+++ b/src/components/MapLibreWebGageMap.tsx
@@ -242,7 +242,10 @@ const MapLibreWebGageWebMap = ({
       <Source id="region-towns" type="geojson" data={townLabelsGeoJson}>
         <Layer {...TOWN_LABELS_LAYER_PROPS} />
       </Source>
-      {markers}
+      {/* Hide gauge icons while a flood level is selected so users aren't
+          confused about whether the icons reflect live status or the
+          selected visualization level. */}
+      {inundationUrl ? null : markers}
     </Map>
   );
 };

--- a/src/components/MapLibreWebGageMap.tsx
+++ b/src/components/MapLibreWebGageMap.tsx
@@ -13,6 +13,7 @@ import TrendIcon, { TREND_ICON_TYPES } from "./TrendIcon";
 import { getTownLabelsGeoJson, TOWN_LABELS_LAYER_PROPS } from "./townLabels";
 import { getRiverOverlaysGeoJson, RIVER_OVERLAY_LAYER_PROPS } from "./riverOverlays";
 import { INUNDATION_FILL_LAYER_PROPS } from "./inundationOverlay";
+import { ROAD_CLOSURE_LINE_LAYER_PROPS, ROAD_CLOSURE_LABEL_LAYER_PROPS } from "./roadClosures";
 import Config from "../config/config";
 import Constants from "expo-constants";
 import floodzillaLocalStyle from "./mapStyles/floodzilla-webstyles.json";
@@ -56,6 +57,7 @@ const MapLibreWebGageWebMap = ({
   inundationUrl,
   onInundationLoad,
   onInundationError,
+  roadClosuresUrl,
 }: InternalGageMapProps) => {
   // The typed map error event doesn't carry a sourceId, so we scope errors to the
   // inundation load by only treating an error as an inundation failure while we're
@@ -226,6 +228,12 @@ const MapLibreWebGageWebMap = ({
       {inundationUrl ? (
         <Source id="inundation" type="geojson" data={inundationUrl}>
           <Layer {...INUNDATION_FILL_LAYER_PROPS} />
+        </Source>
+      ) : null}
+      {roadClosuresUrl ? (
+        <Source id="road-closures" type="geojson" data={roadClosuresUrl}>
+          <Layer {...ROAD_CLOSURE_LINE_LAYER_PROPS} />
+          <Layer {...ROAD_CLOSURE_LABEL_LAYER_PROPS} />
         </Source>
       ) : null}
       <Source id="region-rivers" type="geojson" data={riverOverlaysGeoJson}>

--- a/src/components/__tests__/InundationControl.test.tsx
+++ b/src/components/__tests__/InundationControl.test.tsx
@@ -62,4 +62,15 @@ describe("InundationControl", () => {
     expect(getByText("20000 cfs")).toBeTruthy();
     expect(getByText("42500 cfs")).toBeTruthy();
   });
+
+  it("opens the info popup when the info button is pressed", () => {
+    const { getByLabelText, queryByText, getByText } = render(
+      <InundationControl levels={levels} selectedKey={null} onSelect={jest.fn()} />
+    );
+    // Popup content is not rendered until the info button is pressed.
+    expect(queryByText("map.info.intro")).toBeNull();
+    fireEvent.press(getByLabelText("map.info.buttonLabel"));
+    expect(getByText("map.info.intro")).toBeTruthy();
+    expect(getByText("map.info.roadsNote")).toBeTruthy();
+  });
 });

--- a/src/components/__tests__/InundationControl.test.tsx
+++ b/src/components/__tests__/InundationControl.test.tsx
@@ -5,7 +5,7 @@ import InundationControl from "../InundationControl";
 import type { InundationLevel } from "../inundationOverlay";
 
 jest.mock("@common-ui/contexts/LocaleContext", () => ({
-  useLocale: () => ({ t: (key: string) => key }),
+  useLocale: () => ({ t: (key: string) => key, locale: "en" }),
 }));
 
 jest.mock("@utils/utils", () => ({
@@ -13,9 +13,27 @@ jest.mock("@utils/utils", () => ({
 }));
 
 const levels: InundationLevel[] = [
-  { key: "minor", labelTx: "map.levelMinor", cfs: 20000, url: "u1" },
-  { key: "moderate", labelTx: "map.levelModerate", cfs: 32200, url: "u2" },
-  { key: "major", labelTx: "map.levelMajor", cfs: 42500, url: "u3" },
+  {
+    key: "minor",
+    label: { en: "Minor", es: "Menor" },
+    cfs: 20000,
+    url: "u1",
+    roadClosuresUrl: null,
+  },
+  {
+    key: "moderate",
+    label: { en: "Moderate", es: "Moderada" },
+    cfs: 32200,
+    url: "u2",
+    roadClosuresUrl: null,
+  },
+  {
+    key: "major",
+    label: { en: "Major", es: "Mayor" },
+    cfs: 42500,
+    url: "u3",
+    roadClosuresUrl: null,
+  },
 ];
 
 describe("InundationControl", () => {
@@ -24,7 +42,7 @@ describe("InundationControl", () => {
     const { getByText } = render(
       <InundationControl levels={levels} selectedKey={null} onSelect={onSelect} />
     );
-    fireEvent.press(getByText("map.levelModerate"));
+    fireEvent.press(getByText("Moderate"));
     expect(onSelect).toHaveBeenCalledWith("moderate");
   });
 

--- a/src/components/__tests__/inundationOverlay.test.ts
+++ b/src/components/__tests__/inundationOverlay.test.ts
@@ -1,35 +1,98 @@
-import { getInundationLevels, INUNDATION_FILL_LAYER_PROPS } from "../inundationOverlay";
-
-const TEST_URL_FOR_TESTING = "https://this.does.not.exist/";
+import {
+  fetchInundationLevels,
+  getLevelsConfigUrl,
+  localizeLevelLabel,
+  INUNDATION_FILL_LAYER_PROPS,
+} from "../inundationOverlay";
 
 jest.mock("../../config/config", () => ({
   __esModule: true,
-  default: { INUNDATION_GEOJSON_BASE_URL: TEST_URL_FOR_TESTING },
+  default: { INUNDATION_GEOJSON_BASE_URL: "https://storage.googleapis.com/fz-dev-public/" },
 }));
 
-describe("getInundationLevels", () => {
-  it("returns the three Carnation cfs levels in ascending order", () => {
-    const levels = getInundationLevels();
-    expect(levels.map((l) => l.cfs)).toEqual([20000, 32200, 42500]);
-    expect(levels.map((l) => l.key)).toEqual(["minor", "moderate", "major"]);
+const BASE = "https://storage.googleapis.com/fz-dev-public/";
+
+function mockFetch(body: unknown, ok = true) {
+  globalThis.fetch = jest.fn().mockResolvedValue({ ok, json: async () => body }) as never;
+}
+
+const config = {
+  levels: [
+    {
+      key: "minor",
+      label: { en: "Minor", es: "Menor" },
+      cfs: 20000,
+      file: "FloodExtent_20000CFS_fixed_simplified.geojson",
+      roadClosuresFile: "RoadClosures_20000CFS.geojson",
+    },
+    {
+      key: "major",
+      label: { en: "Major", es: "Mayor" },
+      cfs: 42500,
+      file: "FloodExtent_42500CFS_fixed_simplified.geojson",
+    },
+  ],
+};
+
+describe("getLevelsConfigUrl", () => {
+  it("builds the per-region config url", () => {
+    expect(getLevelsConfigUrl(1)).toBe(BASE + "flood-viz-levels-region-1.json");
+  });
+});
+
+describe("fetchInundationLevels", () => {
+  it("fetches the region config and builds each url from base + file", async () => {
+    mockFetch(config);
+    const levels = await fetchInundationLevels(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith(BASE + "flood-viz-levels-region-1.json");
+    expect(levels?.map((l) => l.key)).toEqual(["minor", "major"]);
+    expect(levels?.[0].url).toBe(BASE + "FloodExtent_20000CFS_fixed_simplified.geojson");
+    expect(levels?.[0].label).toEqual({ en: "Minor", es: "Menor" });
   });
 
-  it("builds each url from the config base + filename", () => {
-    const levels = getInundationLevels();
-    expect(levels[0].url).toBe(
-      TEST_URL_FOR_TESTING + "FloodExtent_20000CFS_fixed_simplified.geojson"
-    );
-    expect(levels[2].url).toBe(
-      TEST_URL_FOR_TESTING + "FloodExtent_42500CFS_fixed_simplified.geojson"
-    );
+  it("builds roadClosuresUrl from base + roadClosuresFile, or null when absent", async () => {
+    mockFetch(config);
+    const levels = await fetchInundationLevels(1);
+    expect(levels?.[0].roadClosuresUrl).toBe(BASE + "RoadClosures_20000CFS.geojson");
+    expect(levels?.[1].roadClosuresUrl).toBeNull();
   });
 
-  it("maps each level to its i18n label key", () => {
-    expect(getInundationLevels().map((l) => l.labelTx)).toEqual([
-      "map.levelMinor",
-      "map.levelModerate",
-      "map.levelMajor",
-    ]);
+  it("accepts a bare array config too", async () => {
+    mockFetch(config.levels);
+    const levels = await fetchInundationLevels(1);
+    expect(levels?.map((l) => l.cfs)).toEqual([20000, 42500]);
+  });
+
+  it("returns null when the config is missing (404)", async () => {
+    mockFetch(null, false);
+    expect(await fetchInundationLevels(2)).toBeNull();
+  });
+
+  it("returns null when the body has the wrong shape", async () => {
+    mockFetch({ nope: true });
+    expect(await fetchInundationLevels(1)).toBeNull();
+  });
+
+  it("returns null on a network error", async () => {
+    globalThis.fetch = jest.fn().mockRejectedValue(new Error("offline")) as never;
+    expect(await fetchInundationLevels(1)).toBeNull();
+  });
+});
+
+describe("localizeLevelLabel", () => {
+  const label = { en: "Minor", es: "Menor" };
+
+  it("picks the active locale", () => {
+    expect(localizeLevelLabel(label, "es")).toBe("Menor");
+  });
+
+  it("uses the base language of a regional locale", () => {
+    expect(localizeLevelLabel(label, "en-US")).toBe("Minor");
+  });
+
+  it("falls back to english, then to any value present", () => {
+    expect(localizeLevelLabel(label, "fr")).toBe("Minor");
+    expect(localizeLevelLabel({ de: "Gering" }, "fr")).toBe("Gering");
   });
 });
 

--- a/src/components/inundationOverlay.ts
+++ b/src/components/inundationOverlay.ts
@@ -3,45 +3,87 @@ import Config from "@config/config";
 
 export type InundationLevel = {
   key: string;
-  labelTx: string;
+  // Display label per locale, e.g. { en: "Minor", es: "Menor" }. Resolved for the
+  // active locale by localizeLevelLabel. Lives in the remote config so levels are
+  // fully data-driven (no app i18n key needed to add one).
+  label: Record<string, string>;
   cfs: number;
+  // GeoJSON URL of the flood-extent fill for this level.
   url: string;
+  // GeoJSON URL of the road closures shown at this level, or null when the config
+  // doesn't list a road file for it.
+  roadClosuresUrl: string | null;
 };
 
-const LEVEL_FILES: { key: string; labelTx: string; cfs: number; file: string }[] = [
-  {
-    key: "minor",
-    labelTx: "map.levelMinor",
-    cfs: 20000,
-    file: "FloodExtent_20000CFS_fixed_simplified.geojson",
-  },
-  {
-    key: "moderate",
-    labelTx: "map.levelModerate",
-    cfs: 32200,
-    file: "FloodExtent_32200CFS_fixed_simplified.geojson",
-  },
-  {
-    key: "major",
-    labelTx: "map.levelMajor",
-    cfs: 42500,
-    file: "FloodExtent_42500CFS_fixed_simplified.geojson",
-  },
-];
+// The region config file's shape (untrusted input — fields are validated before
+// use). Accepts either a bare array of levels or a { levels: [...] } wrapper.
+type RawLevel = {
+  key?: string;
+  label?: Record<string, string>;
+  cfs?: number;
+  file?: string;
+  roadClosuresFile?: string;
+};
+type RawConfig = { levels?: RawLevel[] } | RawLevel[] | null;
 
 function baseUrl(): string {
   const base = Config.INUNDATION_GEOJSON_BASE_URL;
   return base.endsWith("/") ? base : base + "/";
 }
 
-export function getInundationLevels(): InundationLevel[] {
+// URL of the per-region level config, served from the same bucket as the
+// FloodExtent GeoJSON, e.g. ".../flood-viz-levels-region-1.json".
+export function getLevelsConfigUrl(regionId: number): string {
+  return `${baseUrl()}flood-viz-levels-region-${regionId}.json`;
+}
+
+// Fetch and normalize the inundation levels for a region. Returns null when the
+// config is absent (404) or unusable (network/parse error, wrong shape) — the
+// caller hides the Flood Visualizer control in that case. Never rejects.
+export async function fetchInundationLevels(regionId: number): Promise<InundationLevel[] | null> {
   const base = baseUrl();
-  return LEVEL_FILES.map(({ key, labelTx, cfs, file }) => ({
-    key,
-    labelTx,
-    cfs,
-    url: base + file,
-  }));
+  let res: Response;
+  try {
+    res = await fetch(getLevelsConfigUrl(regionId));
+  } catch {
+    return null;
+  }
+  if (!res.ok) {
+    return null;
+  }
+  let data: RawConfig;
+  try {
+    data = (await res.json()) as RawConfig;
+  } catch {
+    return null;
+  }
+  const raw = Array.isArray(data) ? data : data?.levels;
+  if (!Array.isArray(raw)) {
+    return null;
+  }
+  const levels = raw
+    .filter(
+      (l): l is RawLevel & { key: string; file: string } =>
+        typeof l?.key === "string" && typeof l?.file === "string"
+    )
+    .map((l) => ({
+      key: l.key,
+      label: l.label && typeof l.label === "object" ? l.label : {},
+      cfs: typeof l.cfs === "number" ? l.cfs : 0,
+      url: base + l.file,
+      roadClosuresUrl: l.roadClosuresFile ? base + l.roadClosuresFile : null,
+    }));
+  return levels.length > 0 ? levels : null;
+}
+
+// Resolve a level's localized label, falling back from the active locale's base
+// language (e.g. "en-US" -> "en") to English to whatever's present.
+export function localizeLevelLabel(label: Record<string, string>, locale: string): string {
+  if (!label) {
+    return "";
+  }
+  const lang = (locale || "en").split("-")[0];
+  return label[lang] ?? label.en ?? Object.values(label)[0] ?? "";
 }
 
 // Single translucent fill shared by all levels (only one is shown at a time).

--- a/src/components/roadClosures.ts
+++ b/src/components/roadClosures.ts
@@ -1,0 +1,62 @@
+import type {
+  LineLayerSpecification,
+  SymbolLayerSpecification,
+} from "@maplibre/maplibre-gl-style-spec";
+import { Colors } from "@common-ui/constants/colors";
+
+// Road segments that flood at each inundation level. The GeoJSON for each level
+// is served from the same bucket as the FloodExtent files; the per-level road URL
+// comes from the region config (`roadClosuresFile` on each level — see
+// inundationOverlay.ts), so the level→file mapping is not hardcoded here. Each
+// feature carries a semantic `status` ("normal" | "nearFlooding" | "flooding")
+// and a `label` — the line layer maps the status to a gauge-status color in code
+// (below), so the color is not baked into the GeoJSON.
+
+// Single line layer for all levels. The color is data-driven from each feature's
+// `status`, mapped here to the app's gauge-status palette (the single source of
+// truth in colors.ts) so hex values never live in the GeoJSON. Declared above
+// the inundation fill so the highlighted road reads on top of the flood area.
+export const ROAD_CLOSURE_LINE_LAYER_PROPS: Omit<LineLayerSpecification, "source"> = {
+  id: "road-closures-line",
+  type: "line",
+  layout: {
+    "line-cap": "round",
+    "line-join": "round",
+  },
+  paint: {
+    "line-color": [
+      "match",
+      ["get", "status"],
+      "normal",
+      Colors.success, // green
+      "nearFlooding",
+      Colors.warning, // yellow
+      "flooding",
+      Colors.danger, // red
+      Colors.warning, // fallback for an unknown status
+    ],
+    "line-width": 4,
+    "line-opacity": 1,
+  },
+};
+
+// A single centered label per road, riding along the line (e.g. "NE 124th -
+// Possible Closure" at the minor level, "NE 124th - Closed" above). Text is dark
+// with a white halo for legibility over the flood fill and basemap — the line
+// color already signals severity, so the label stays readable rather than tinted.
+export const ROAD_CLOSURE_LABEL_LAYER_PROPS: Omit<SymbolLayerSpecification, "source"> = {
+  id: "road-closures-label",
+  type: "symbol",
+  layout: {
+    "text-field": ["get", "label"],
+    "text-font": ["Noto Sans Regular"],
+    "symbol-placement": "line-center",
+    "text-max-width": 12,
+    "text-size": ["interpolate", ["linear"], ["zoom"], 10, 11, 14, 14],
+  },
+  paint: {
+    "text-color": "hsl(0, 0%, 8%)",
+    "text-halo-color": "white",
+    "text-halo-width": 2,
+  },
+};

--- a/src/components/useInundationLevels.ts
+++ b/src/components/useInundationLevels.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import { fetchInundationLevels, type InundationLevel } from "./inundationOverlay";
+
+export type InundationLevelsState = {
+  // The region's levels, or null when there is no usable config (control hidden).
+  levels: InundationLevel[] | null;
+  // False until the first fetch for the current region settles, so the caller can
+  // avoid flashing the control on while the config is still loading.
+  ready: boolean;
+};
+
+// Load the per-region Flood Visualizer level config from GCS. Refetches when the
+// region changes; a stale in-flight response is ignored.
+export function useInundationLevels(regionId: number | undefined): InundationLevelsState {
+  const [state, setState] = useState<InundationLevelsState>({ levels: null, ready: false });
+
+  useEffect(() => {
+    if (regionId === undefined) {
+      setState({ levels: null, ready: false });
+      return undefined;
+    }
+    let cancelled = false;
+    setState({ levels: null, ready: false });
+    fetchInundationLevels(regionId)
+      .then((levels) => {
+        if (!cancelled) {
+          setState({ levels, ready: true });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState({ levels: null, ready: true });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [regionId]);
+
+  return state;
+}

--- a/src/config/config.base.ts
+++ b/src/config/config.base.ts
@@ -94,7 +94,7 @@ const BaseConfig: {
   GAGE_IMAGE_BASE_URL: "https://svpastorage.blob.core.windows.net/uploads/",
   DONATION_URL: "https://www.paypal.com/donate/?hosted_button_id=HT6T3U5F2C4NG",
   DEFAULT_MAP_TILE_BASE_URL: "https://floodzilla.com/maps",
-  INUNDATION_GEOJSON_BASE_URL: "https://floodzilla.com/map/",
+  INUNDATION_GEOJSON_BASE_URL: "https://storage.googleapis.com/fz-dev-public/",
 
   SVPA_URL: "https://svpa.us",
   SVPA_PHONE: "425-549-0316",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -278,9 +278,6 @@ const en = {
     floodVisualizerTitle: "Flood Visualizer",
     loadError: "Couldn't load flood data. Please try again.",
     levelNone: "None",
-    levelMinor: "Minor",
-    levelModerate: "Moderate",
-    levelMajor: "Major",
   },
   calloutReading: {
     lastReading: "Last Reading",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -278,6 +278,23 @@ const en = {
     floodVisualizerTitle: "Flood Visualizer",
     loadError: "Couldn't load flood data. Please try again.",
     levelNone: "None",
+    info: {
+      buttonLabel: "About the Flood Visualizer",
+      title: "About the Flood Visualizer",
+      intro: "These are inundation maps of the Lower Snoqualmie Valley.",
+      extent:
+        "The blue area shows the maximum projected extent of the water over the course of an entire flooding event. It is not a snapshot of a single moment in time.",
+      cfs: "The flow values (CFS) are based on the Snoqualmie River gauge near Carnation.",
+      modeled:
+        "This is modeled data, and every flood behaves differently. Treat the map as a guide, not a guarantee.",
+      roadsHeading: "Road colors",
+      roadOpen: "Open — flooding is not expected at this level.",
+      roadPossible: "Possible closure — water may be reaching the road.",
+      roadClosed: "Closed — the road is expected to be impassable.",
+      roadsNote:
+        "Road colors are estimates. A road may close earlier or later than shown, and some impacted roads may not appear on the map.",
+      close: "Close",
+    },
   },
   calloutReading: {
     lastReading: "Last Reading",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -282,6 +282,23 @@ const es = {
     floodVisualizerTitle: "Visualizador de inundaciones",
     loadError: "No se pudieron cargar los datos de inundación. Inténtalo de nuevo.",
     levelNone: "Ninguna",
+    info: {
+      buttonLabel: "Acerca del Visualizador de inundaciones",
+      title: "Acerca del Visualizador de inundaciones",
+      intro: "Estos son mapas de inundación del bajo Valle de Snoqualmie.",
+      extent:
+        "El área azul muestra la extensión máxima proyectada del agua durante todo un evento de inundación. No es una instantánea de un solo momento en el tiempo.",
+      cfs: "Los valores de caudal (ft³/s) se basan en el medidor del río Snoqualmie cerca de Carnation.",
+      modeled:
+        "Estos son datos modelados, y cada inundación se comporta de manera diferente. Usa el mapa como guía, no como garantía.",
+      roadsHeading: "Colores de las carreteras",
+      roadOpen: "Abierta: no se espera inundación en este nivel.",
+      roadPossible: "Posible cierre: el agua podría estar llegando a la carretera.",
+      roadClosed: "Cerrada: se espera que la carretera sea intransitable.",
+      roadsNote:
+        "Los colores de las carreteras son estimaciones. Una carretera puede cerrarse antes o después de lo indicado, y algunas carreteras afectadas podrían no aparecer en el mapa.",
+      close: "Cerrar",
+    },
   },
   calloutReading: {
     lastReading: "Última medición",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -282,9 +282,6 @@ const es = {
     floodVisualizerTitle: "Visualizador de inundaciones",
     loadError: "No se pudieron cargar los datos de inundación. Inténtalo de nuevo.",
     levelNone: "Ninguna",
-    levelMinor: "Menor",
-    levelModerate: "Moderada",
-    levelMajor: "Mayor",
   },
   calloutReading: {
     lastReading: "Última medición",

--- a/src/models/MapModels.ts
+++ b/src/models/MapModels.ts
@@ -30,6 +30,10 @@ export type GageMapProps = {
   // network is down). Web fires it from the map error event; native from a HEAD
   // probe of the URL.
   onInundationError?: () => void;
+  // GeoJSON URL of the road segments that flood at the selected inundation
+  // level, drawn as colored, labeled lines above the inundation fill. Served
+  // from the same bucket as the inundation files. Null/undefined renders none.
+  roadClosuresUrl?: string | null;
 };
 
 export type InternalGageMapProps = GageMapProps & {


### PR DESCRIPTION
## Summary

Adds labeled **road-closure lines** to the Flood Visualizer and moves the inundation-level configuration to a per-region file fetched at runtime, so flood levels and their associated GeoJSON are no longer hardcoded in the app.

- **Road closures** render as colored, labeled lines above the flood fill. The color is data-driven from each feature's gauge status (green/yellow/red) rather than baked into the GeoJSON.
- **Region-keyed level config**: levels now load from `flood-viz-levels-region-<id>.json` (per-locale labels + flood and road GeoJSON filenames). The segmented control builds its buttons dynamically and hides entirely when a region has no config.
- Drops the hardcoded level/road file tables and the now-orphaned `map.levelMinor/Moderate/Major` i18n keys; `useLocale()` now exposes the active locale for label localization.

## Data source

The config and GeoJSON files this consumes are checked into the [`snovalleypa/river-data`](https://github.com/snovalleypa/river-data) repo (served from GCS), not this repo:

- `floodzuki_data/flood-viz-levels-region-1.json` ([link](https://github.com/snovalleypa/river-data/blob/main/floodzuki_data/flood-viz-levels-region-1.json)) — the per-region level config
- `floodzuki_data/FloodExtent_<cfs>CFS_fixed_simplified.geojson` — the road-closure lines per level
- `floodzuki_data/RoadClosures_<cfs>CFS.geojson` — the road-closure lines per level
- `flood_extents/fix_and_simplify.py` — converts the original (very large) ArcGIS-exported flood GeoJSON into the web-consumable simplified version

## Future work

Road-closure data is currently authored by hand. The plan is to generate it from the flood-analysis output in the `svpa-forecast-regression` notebook.

## Test plan

- `npx tsc --noEmit` — clean
- `npx jest inundationOverlay MapLibreWebGageMap` — 29 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
